### PR TITLE
Update Utils.java

### DIFF
--- a/src/yahoofinance/Utils.java
+++ b/src/yahoofinance/Utils.java
@@ -121,7 +121,7 @@ public class Utils {
         try {
             Calendar today = Calendar.getInstance(TimeZone.getTimeZone(YahooFinance.TIMEZONE));
             Calendar parsedDate = Calendar.getInstance(TimeZone.getTimeZone(YahooFinance.TIMEZONE));
-            parsedDate.setTime(format.parse(date));
+            parsedDate.setTime(format.parse(date.trim()));
             
             if(parsedDate.get(Calendar.YEAR) == 1970) {
                 parsedDate.set(Calendar.YEAR, today.get(Calendar.YEAR));


### PR DESCRIPTION
If you try to use the version 1.01 and try to get the Quotes, the method called parseDividendDate is giving an parsing exception. 
Reason:- When trying for the symbol "JCP" and extra space is present in the date and thus the above method fails. Adding trim method in here should fix the problem. Please test it out.