### PR TITLE
Removed setting timezone while parsing date from icharts API response

### DIFF
--- a/src/main/java/yahoofinance/Utils.java
+++ b/src/main/java/yahoofinance/Utils.java
@@ -248,7 +248,6 @@ public class Utils {
 
     public static Calendar parseHistDate(String date) {
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
-        format.setTimeZone(TimeZone.getTimeZone(YahooFinance.TIMEZONE));
         try {
             if (Utils.isParseable(date)) {
                 Calendar c = Calendar.getInstance();


### PR DESCRIPTION
The date that is returned by the API is the correct date and does not need any timezone applied to it <br>
Applying the timezone actually messes up the date. For eg say you ask data for 07-08-2016, then the response from the API is <br>
```
Date,Open,High,Low,Close,Volume,Adj Close
2016-07-08,217.800003,219.809998,214.50,216.779999,4064300,216.779999
```

but when you call `.getHistory().getDate().getTime()` on the stock, the date that is returned is `Thu Jul 07 21:00:00 PDT 2016`