### PR TITLE
Add RxJava support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,11 @@
             <version>1.17</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.reactivex</groupId>
+            <artifactId>rxjava</artifactId>
+            <version>1.2.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/yahoofinance/YahooFinance.java
+++ b/src/main/java/yahoofinance/YahooFinance.java
@@ -7,6 +7,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
+
+import rx.Observable;
+import rx.Subscriber;
 import yahoofinance.histquotes.HistQuotesRequest;
 import yahoofinance.histquotes.Interval;
 import yahoofinance.quotes.fx.FxQuote;
@@ -68,6 +71,26 @@ public class YahooFinance {
     public static Stock get(String symbol) throws IOException {
         return YahooFinance.get(symbol, false);
     }
+
+    /**
+     * Sends a basic quotes request to Yahoo Finance. This will return an {@link Observable} of a Stock object.
+     *
+     * @param symbol    the symbol of the stock for which you want to retrieve information
+     * @return          an {@link Observable} of a {@link Stock} containing the requested information
+     */
+    public static Observable<Stock> getRx(final String symbol) {
+        return Observable.create(new Observable.OnSubscribe<Stock>() {
+            @Override
+            public void call(Subscriber<? super Stock> subscriber) {
+                try {
+                    subscriber.onNext(YahooFinance.get(symbol, false));
+                    subscriber.onCompleted();
+                } catch (IOException e) {
+                    subscriber.onError(e);
+                }
+            }
+        });
+    }
     
     /**
      * Same as the <code>get(String)</code> method, but with the option to include
@@ -85,6 +108,31 @@ public class YahooFinance {
         Map<String, Stock> result = YahooFinance.getQuotes(symbol, includeHistorical);
         return result.get(symbol);
     }
+
+    /**
+     * Same as the <code>getRx(String)</code> method, but with the option to include
+     * historical stock quote data. Including historical data will cause the {@link Stock}
+     * object's member field {@link yahoofinance.histquotes.HistoricalQuote} to be filled in
+     * with the default past year term at monthly intervals.
+     * Returns null if the data can't be retrieved from Yahoo Finance.
+     *
+     * @param symbol                the symbol of the stock for which you want to retrieve information
+     * @param includeHistorical     indicates if the historical quotes should be included.
+     * @return                      an {@link Observable} of a {@link Stock} containing the requested information
+     */
+    public static Observable<Stock> getRx(final String symbol, final boolean includeHistorical) {
+        return Observable.create(new Observable.OnSubscribe<Stock>() {
+            @Override
+            public void call(Subscriber<? super Stock> subscriber) {
+                try {
+                    subscriber.onNext(YahooFinance.getQuotes(symbol, includeHistorical).get(symbol));
+                    subscriber.onCompleted();
+                } catch (IOException e) {
+                    subscriber.onError(e);
+                }
+            }
+        });
+    }
     
     /**
      * Sends a request with the historical quotes included
@@ -98,6 +146,29 @@ public class YahooFinance {
      */
     public static Stock get(String symbol, Interval interval) throws IOException {
         return YahooFinance.get(symbol, HistQuotesRequest.DEFAULT_FROM, HistQuotesRequest.DEFAULT_TO, interval);
+    }
+
+    /**
+     * Sends a request with the historical quotes included
+     * at the specified interval (DAILY, WEEKLY, MONTHLY).
+     * Returns null if the data can't be retrieved from Yahoo Finance.
+     *
+     * @param symbol        the symbol of the stock for which you want to retrieve information
+     * @param interval      the interval of the included historical data
+     * @return              an {@link Observable} of a {@link Stock} containing the requested information
+     */
+    public static Observable<Stock> getRx(final String symbol, final Interval interval) {
+        return Observable.create(new Observable.OnSubscribe<Stock>() {
+            @Override
+            public void call(Subscriber<? super Stock> subscriber) {
+                try {
+                    subscriber.onNext(YahooFinance.get(symbol, HistQuotesRequest.DEFAULT_FROM, HistQuotesRequest.DEFAULT_TO, interval));
+                    subscriber.onCompleted();
+                } catch (IOException e) {
+                    subscriber.onError(e);
+                }
+            }
+        });
     }
     
     /**
@@ -113,6 +184,30 @@ public class YahooFinance {
      */
     public static Stock get(String symbol, Calendar from) throws IOException {
         return YahooFinance.get(symbol, from, HistQuotesRequest.DEFAULT_TO, HistQuotesRequest.DEFAULT_INTERVAL);
+    }
+
+    /**
+     * Sends a request with the historical quotes included
+     * starting from the specified {@link Calendar} date
+     * at the default interval (monthly).
+     * Returns null if the data can't be retrieved from Yahoo Finance.
+     *
+     * @param symbol        the symbol of the stock for which you want to retrieve information
+     * @param from          start date of the historical data
+     * @return              an {@link Observable} of a {@link Stock} containing the requested information
+     */
+    public static Observable<Stock> getRx(final String symbol, final Calendar from) {
+        return Observable.create(new Observable.OnSubscribe<Stock>() {
+            @Override
+            public void call(Subscriber<? super Stock> subscriber) {
+                try {
+                    subscriber.onNext(YahooFinance.get(symbol, from, HistQuotesRequest.DEFAULT_TO, HistQuotesRequest.DEFAULT_INTERVAL));
+                    subscriber.onCompleted();
+                } catch (IOException e) {
+                    subscriber.onError(e);
+                }
+            }
+        });
     }
     
     /**
@@ -130,6 +225,31 @@ public class YahooFinance {
     public static Stock get(String symbol, Calendar from, Interval interval) throws IOException {
         return YahooFinance.get(symbol, from, HistQuotesRequest.DEFAULT_TO, interval);
     }
+
+    /**
+     * Sends a request with the historical quotes included
+     * starting from the specified {@link Calendar} date
+     * at the specified interval.
+     * Returns null if the data can't be retrieved from Yahoo Finance.
+     *
+     * @param symbol        the symbol of the stock for which you want to retrieve information
+     * @param from          start date of the historical data
+     * @param interval      the interval of the included historical data
+     * @return              an {@link Observable} of a {@link Stock} containing the requested information
+     */
+    public static Observable<Stock> getRx(final String symbol, final Calendar from, final Interval interval) {
+        return Observable.create(new Observable.OnSubscribe<Stock>() {
+            @Override
+            public void call(Subscriber<? super Stock> subscriber) {
+                try {
+                    subscriber.onNext(YahooFinance.get(symbol, from, HistQuotesRequest.DEFAULT_TO, interval));
+                    subscriber.onCompleted();
+                } catch (IOException e) {
+                    subscriber.onError(e);
+                }
+            }
+        });
+    }
     
     /**
      * Sends a request with the historical quotes included
@@ -146,6 +266,32 @@ public class YahooFinance {
      */
     public static Stock get(String symbol, Calendar from, Calendar to) throws IOException {
         return YahooFinance.get(symbol, from, to, HistQuotesRequest.DEFAULT_INTERVAL);
+    }
+
+    /**
+     * Sends a request with the historical quotes included
+     * starting from the specified {@link Calendar} date
+     * until the specified Calendar date (to)
+     * at the default interval (monthly).
+     * Returns null if the data can't be retrieved from Yahoo Finance.
+     *
+     * @param symbol        the symbol of the stock for which you want to retrieve information
+     * @param from          start date of the historical data
+     * @param to            end date of the historical data
+     * @return              an {@link Observable} of a {@link Stock} containing the requested information
+     */
+    public static Observable<Stock> getRx(final String symbol, final Calendar from, final Calendar to) {
+        return Observable.create(new Observable.OnSubscribe<Stock>() {
+            @Override
+            public void call(Subscriber<? super Stock> subscriber) {
+                try {
+                    subscriber.onNext(YahooFinance.get(symbol, from, to, HistQuotesRequest.DEFAULT_INTERVAL));
+                    subscriber.onCompleted();
+                } catch (IOException e) {
+                    subscriber.onError(e);
+                }
+            }
+        });
     }
     
     /**
@@ -166,6 +312,33 @@ public class YahooFinance {
         Map<String, Stock> result = YahooFinance.getQuotes(symbol, from, to, interval);
         return result.get(symbol);
     }
+
+    /**
+     * Sends a request with the historical quotes included
+     * starting from the specified {@link Calendar} date
+     * until the specified Calendar date (to)
+     * at the specified interval.
+     * Returns null if the data can't be retrieved from Yahoo Finance.
+     *
+     * @param symbol        the symbol of the stock for which you want to retrieve information
+     * @param from          start date of the historical data
+     * @param to            end date of the historical data
+     * @param interval      the interval of the included historical data
+     * @return              an {@link Observable} of a {@link Stock} containing the requested information
+     */
+    public static Observable<Stock> getRx(final String symbol, final Calendar from, final Calendar to, final Interval interval) {
+        return Observable.create(new Observable.OnSubscribe<Stock>() {
+            @Override
+            public void call(Subscriber<? super Stock> subscriber) {
+                try {
+                    subscriber.onNext(YahooFinance.getQuotes(symbol, from, to, interval).get(symbol));
+                    subscriber.onCompleted();
+                } catch (IOException e) {
+                    subscriber.onError(e);
+                }
+            }
+        });
+    }
     
     /**
     * Sends a basic quotes request to Yahoo Finance. This will return a {@link Map} object
@@ -184,6 +357,34 @@ public class YahooFinance {
     */
     public static Map<String, Stock> get(String[] symbols) throws IOException {
         return YahooFinance.get(symbols, false);
+    }
+
+    /**
+     * Sends a basic quotes request to Yahoo Finance. This will return a {@link Map} object
+     * that links the symbols to their respective {@link Stock} objects.
+     * The Stock objects have their {@link yahoofinance.quotes.stock.StockQuote}, {@link yahoofinance.quotes.stock.StockStats}
+     * and {@link yahoofinance.quotes.stock.StockDividend} member fields
+     * filled in with the available data.
+     * <p>
+     * All the information is retrieved in a single request to Yahoo Finance.
+     * The returned Map only includes the Stocks that could
+     * successfully be retrieved from Yahoo Finance.
+     *
+     * @param symbols    the symbols of the stocks for which you want to retrieve information
+     * @return           an {@link Observable} of a Map that links the symbols to their respective Stock objects
+     */
+    public static Observable<Map<String, Stock>> getRx(final String[] symbols) {
+        return Observable.create(new Observable.OnSubscribe<Map<String, Stock>>() {
+            @Override
+            public void call(Subscriber<? super Map<String, Stock>> subscriber) {
+                try {
+                    subscriber.onNext(YahooFinance.get(symbols, false));
+                    subscriber.onCompleted();
+                } catch (IOException e) {
+                    subscriber.onError(e);
+                }
+            }
+        });
     }
     
     /**
@@ -206,6 +407,36 @@ public class YahooFinance {
     public static Map<String, Stock> get(String[] symbols, boolean includeHistorical) throws IOException {
         return YahooFinance.getQuotes(Utils.join(symbols, ","), includeHistorical);
     }
+
+    /**
+     * Same as the <code>get(String[])</code> method, but with the option to include
+     * historical stock quote data. Including historical data will cause the {@link Stock}
+     * objects their member field {@link yahoofinance.histquotes.HistoricalQuote} to be filled in
+     * with the default past year term at monthly intervals.
+     * <p>
+     * The latest quotes will be retrieved in a single request to Yahoo Finance.
+     * For the historical quotes (if includeHistorical),
+     * a separate request will be sent for each requested stock.
+     * The returned Map only includes the Stocks that could
+     * successfully be retrieved from Yahoo Finance.
+     *
+     * @param symbols               the symbols of the stocks for which you want to retrieve information
+     * @param includeHistorical     indicates if the historical quotes should be included
+     * @return                      an {@link Observable} of a Map that links the symbols to their respective Stock objects
+     */
+    public static Observable<Map<String, Stock>> getRx(final String[] symbols, final boolean includeHistorical) {
+        return Observable.create(new Observable.OnSubscribe<Map<String, Stock>>() {
+            @Override
+            public void call(Subscriber<? super Map<String, Stock>> subscriber) {
+                try {
+                    subscriber.onNext(YahooFinance.getQuotes(Utils.join(symbols, ","), includeHistorical));
+                    subscriber.onCompleted();
+                } catch (IOException e) {
+                    subscriber.onError(e);
+                }
+            }
+        });
+    }
     
     /**
      * Sends a request for multiple stocks with the historical quotes included
@@ -225,6 +456,34 @@ public class YahooFinance {
     public static Map<String, Stock> get(String[] symbols, Interval interval) throws IOException {
         return YahooFinance.getQuotes(Utils.join(symbols, ","), HistQuotesRequest.DEFAULT_FROM, HistQuotesRequest.DEFAULT_TO, interval);
     }
+
+    /**
+     * Sends a request for multiple stocks with the historical quotes included
+     * from the past year,
+     * at the specified interval. (DAILY, WEEKLY, MONTHLY)
+     * <p>
+     * The latest quotes will be retrieved in a single request to Yahoo Finance.
+     * For the historical quotes, a separate request will be sent for each requested stock.
+     * The returned Map only includes the Stocks that could
+     * successfully be retrieved from Yahoo Finance.
+     *
+     * @param symbols               the symbols of the stocks for which you want to retrieve information
+     * @param interval              the interval of the included historical data
+     * @return                      an {@link Observable} of a Map that links the symbols to their respective Stock objects
+     */
+    public static Observable<Map<String, Stock>> getRx(final String[] symbols, final Interval interval) {
+        return Observable.create(new Observable.OnSubscribe<Map<String, Stock>>() {
+            @Override
+            public void call(Subscriber<? super Map<String, Stock>> subscriber) {
+                try {
+                    subscriber.onNext(YahooFinance.getQuotes(Utils.join(symbols, ","), HistQuotesRequest.DEFAULT_FROM, HistQuotesRequest.DEFAULT_TO, interval));
+                    subscriber.onCompleted();
+                } catch (IOException e) {
+                    subscriber.onError(e);
+                }
+            }
+        });
+    }
     
     /**
      * Sends a request for multiple stocks with the historical quotes included
@@ -243,6 +502,34 @@ public class YahooFinance {
      */
     public static Map<String, Stock> get(String[] symbols, Calendar from) throws IOException {
         return YahooFinance.getQuotes(Utils.join(symbols, ","), from, HistQuotesRequest.DEFAULT_TO, HistQuotesRequest.DEFAULT_INTERVAL);
+    }
+
+    /**
+     * Sends a request for multiple stocks with the historical quotes included
+     * starting from the specified {@link Calendar} date until today,
+     * at the default interval (monthly).
+     * <p>
+     * The latest quotes will be retrieved in a single request to Yahoo Finance.
+     * For the historical quotes, a separate request will be sent for each requested stock.
+     * The returned Map only includes the Stocks that could
+     * successfully be retrieved from Yahoo Finance.
+     *
+     * @param symbols               the symbols of the stocks for which you want to retrieve information
+     * @param from                  start date of the historical data
+     * @return                      an {@link Observable} of a Map that links the symbols to their respective Stock objects
+     */
+    public static Observable<Map<String, Stock>> getRx(final String[] symbols, final Calendar from) {
+        return Observable.create(new Observable.OnSubscribe<Map<String, Stock>>() {
+            @Override
+            public void call(Subscriber<? super Map<String, Stock>> subscriber) {
+                try {
+                    subscriber.onNext(YahooFinance.getQuotes(Utils.join(symbols, ","), from, HistQuotesRequest.DEFAULT_TO, HistQuotesRequest.DEFAULT_INTERVAL));
+                    subscriber.onCompleted();
+                } catch (IOException e) {
+                    subscriber.onError(e);
+                }
+            }
+        });
     }
     
     /**
@@ -264,6 +551,36 @@ public class YahooFinance {
     public static Map<String, Stock> get(String[] symbols, Calendar from, Interval interval) throws IOException {
         return YahooFinance.getQuotes(Utils.join(symbols, ","), from, HistQuotesRequest.DEFAULT_TO, interval);
     }
+
+
+    /**
+     * Sends a request for multiple stocks with the historical quotes included
+     * starting from the specified {@link Calendar} date until today,
+     * at the specified interval.
+     * <p>
+     * The latest quotes will be retrieved in a single request to Yahoo Finance.
+     * For the historical quotes, a separate request will be sent for each requested stock.
+     * The returned Map only includes the Stocks that could
+     * successfully be retrieved from Yahoo Finance.
+     *
+     * @param symbols               the symbols of the stocks for which you want to retrieve information
+     * @param from                  start date of the historical data
+     * @param interval              the interval of the included historical data
+     * @return                      an {@link Observable} of a Map that links the symbols to their respective Stock objects
+     */
+    public static Observable<Map<String, Stock>> getRx(final String[] symbols, final Calendar from, final Interval interval) {
+        return Observable.create(new Observable.OnSubscribe<Map<String, Stock>>() {
+            @Override
+            public void call(Subscriber<? super Map<String, Stock>> subscriber) {
+                try {
+                    subscriber.onNext(YahooFinance.getQuotes(Utils.join(symbols, ","), from, HistQuotesRequest.DEFAULT_TO, interval));
+                    subscriber.onCompleted();
+                } catch (IOException e) {
+                    subscriber.onError(e);
+                }
+            }
+        });
+    }
     
     /**
      * Sends a request for multiple stocks with the historical quotes included
@@ -284,6 +601,36 @@ public class YahooFinance {
      */
     public static Map<String, Stock> get(String[] symbols, Calendar from, Calendar to) throws IOException {
         return YahooFinance.getQuotes(Utils.join(symbols, ","), from, to, HistQuotesRequest.DEFAULT_INTERVAL);
+    }
+
+    /**
+     * Sends a request for multiple stocks with the historical quotes included
+     * starting from the specified {@link Calendar} date
+     * until the specified Calendar date (to)
+     * at the default interval (monthly).
+     * <p>
+     * The latest quotes will be retrieved in a single request to Yahoo Finance.
+     * For the historical quotes, a separate request will be sent for each requested stock.
+     * The returned Map only includes the Stocks that could
+     * successfully be retrieved from Yahoo Finance.
+     *
+     * @param symbols               the symbols of the stocks for which you want to retrieve information
+     * @param from                  start date of the historical data
+     * @param to                    end date of the historical data
+     * @return                      an {@link Observable} of a Map that links the symbols to their respective Stock objects
+     */
+    public static Observable<Map<String, Stock>> getRx(final String[] symbols, final Calendar from, final Calendar to) {
+        return Observable.create(new Observable.OnSubscribe<Map<String, Stock>>() {
+            @Override
+            public void call(Subscriber<? super Map<String, Stock>> subscriber) {
+                try {
+                    subscriber.onNext(YahooFinance.get(symbols, from, to));
+                    subscriber.onCompleted();
+                } catch (IOException e) {
+                    subscriber.onError(e);
+                }
+            }
+        });
     }
     
     /**
@@ -307,6 +654,37 @@ public class YahooFinance {
     public static Map<String, Stock> get(String[] symbols, Calendar from, Calendar to, Interval interval) throws IOException {
         return YahooFinance.getQuotes(Utils.join(symbols, ","), from, to, interval);
     }
+
+    /**
+     * Sends a request for multiple stocks with the historical quotes included
+     * starting from the specified {@link Calendar} date
+     * until the specified Calendar date (to)
+     * at the specified interval.
+     * <p>
+     * The latest quotes will be retrieved in a single request to Yahoo Finance.
+     * For the historical quotes, a separate request will be sent for each requested stock.
+     * The returned Map only includes the Stocks that could
+     * successfully be retrieved from Yahoo Finance.
+     *
+     * @param symbols               the symbols of the stocks for which you want to retrieve information
+     * @param from                  start date of the historical data
+     * @param to                    end date of the historical data
+     * @param interval              the interval of the included historical data
+     * @return                      an {@link Observable} of a Map that links the symbols to their respective Stock objects
+     */
+    public static Observable<Map<String, Stock>> getRx(final String[] symbols, final Calendar from, final Calendar to, final Interval interval) {
+        return Observable.create(new Observable.OnSubscribe<Map<String, Stock>>() {
+            @Override
+            public void call(Subscriber<? super Map<String, Stock>> subscriber) {
+                try {
+                    subscriber.onNext(YahooFinance.get(symbols, from, to, interval));
+                    subscriber.onCompleted();
+                } catch (IOException e) {
+                    subscriber.onError(e);
+                }
+            }
+        });
+    }
     
     /**
      * Sends a request for a single FX rate.
@@ -328,6 +706,35 @@ public class YahooFinance {
         FxQuotesRequest request = new FxQuotesRequest(symbol);
         return request.getSingleResult();
     }
+
+    /**
+     * Sends a request for a single FX rate.
+     * Some common symbols can easily be found in the ENUM {@link yahoofinance.quotes.fx.FxSymbols}
+     * Some examples of accepted symbols:
+     * <ul>
+     * <li> EURUSD=X
+     * <li> USDEUR=X
+     * <li> USDGBP=X
+     * <li> AUDGBP=X
+     * <li> CADUSD=X
+     * </ul>
+     *
+     * @param symbol    symbol for the FX rate you want to request
+     * @return          an {@link Observable} for a quote for the requested FX rate
+     */
+    public static Observable<FxQuote> getFxRx(final String symbol) {
+        return Observable.create(new Observable.OnSubscribe<FxQuote>() {
+            @Override
+            public void call(Subscriber<? super FxQuote> subscriber) {
+                try {
+                    subscriber.onNext(YahooFinance.getFx(symbol));
+                    subscriber.onCompleted();
+                } catch (IOException e) {
+                    subscriber.onError(e);
+                }
+            }
+        });
+    }
     
     /**
      * Sends a single request to Yahoo Finance to retrieve a quote 
@@ -348,6 +755,30 @@ public class YahooFinance {
             result.put(quote.getSymbol(), quote);
         }
         return result;
+    }
+
+    /**
+     * Sends a single request to Yahoo Finance to retrieve a quote
+     * for all the requested FX symbols.
+     * See <code>getFx(String)</code> for more information on the
+     * accepted FX symbols.
+     *
+     * @param symbols   an array of FX symbols
+     * @return          an {@link Observable} of the requested FX symbols mapped to their respective quotes
+     * @see             #getFx(java.lang.String)
+     */
+    public static Observable<Map<String, FxQuote>> getFxRx(final String[] symbols) {
+        return Observable.create(new Observable.OnSubscribe<Map<String, FxQuote>>() {
+            @Override
+            public void call(Subscriber<? super Map<String, FxQuote>> subscriber) {
+                try {
+                    subscriber.onNext(YahooFinance.getFx(symbols));
+                    subscriber.onCompleted();
+                } catch (IOException e) {
+                    subscriber.onError(e);
+                }
+            }
+        });
     }
     
     private static Map<String, Stock> getQuotes(String query, boolean includeHistorical) throws IOException {

--- a/src/test/java/yahoofinance/RxTest.java
+++ b/src/test/java/yahoofinance/RxTest.java
@@ -1,0 +1,168 @@
+package yahoofinance;
+
+import org.junit.Test;
+
+import rx.Observable;
+import rx.functions.Action1;
+import yahoofinance.mock.MockedServersTest;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Calendar;
+import java.util.TimeZone;
+
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author Benjamin Butzow
+ * @author Stijn Strickx
+ */
+public class RxTest extends MockedServersTest {
+
+    @Test
+    public void europeStockQuoteTest() throws IOException {
+        Observable<Stock> stockObservable = YahooFinance.getRx("AIR.PA");
+        stockObservable.subscribe(new Action1<Stock>() {
+                                      @Override
+                                      public void call(Stock stock) {
+                                          assertEquals("AIR.PA", stock.getSymbol());
+                                          assertEquals("AIRBUS GROUP", stock.getName());
+                                          assertEquals("EUR", stock.getCurrency());
+                                          assertEquals("PAR", stock.getStockExchange());
+
+                                          assertNotNull(stock.getQuote());
+                                          assertNotNull(stock.getStats());
+                                          assertNotNull(stock.getDividend());
+
+                                          assertEquals(new BigDecimal("54.93"), stock.getQuote().getAsk());
+                                          assertEquals(new Long(700), stock.getQuote().getAskSize());
+                                          assertEquals(new BigDecimal("54.00"), stock.getQuote().getBid());
+                                          assertEquals(new Long(42000), stock.getQuote().getBidSize());
+                                          assertEquals(new BigDecimal("50.34"), stock.getQuote().getPrice());
+                                          assertEquals(new Long(813), stock.getQuote().getLastTradeSize());
+                                          assertEquals(new BigDecimal("50.58"), stock.getQuote().getOpen());
+                                          assertEquals(new BigDecimal("51.00"), stock.getQuote().getPreviousClose());
+
+                                          assertEquals(new BigDecimal("50.10"), stock.getQuote().getDayLow());
+                                          assertEquals(new BigDecimal("50.85"), stock.getQuote().getDayHigh());
+                                          assertEquals(new BigDecimal("48.07"), stock.getQuote().getYearLow());
+                                          assertEquals(new BigDecimal("68.50"), stock.getQuote().getYearHigh());
+                                          assertEquals(new BigDecimal("51.81"), stock.getQuote().getPriceAvg50());
+                                          assertEquals(new BigDecimal("55.21"), stock.getQuote().getPriceAvg200());
+
+                                          assertEquals(new Long(1460112), stock.getQuote().getVolume());
+                                          assertEquals(new Long(2211770), stock.getQuote().getAvgVolume());
+                                          assertEquals("8/8/2016", stock.getQuote().getLastTradeDateStr());
+                                          assertEquals("5:35pm", stock.getQuote().getLastTradeTimeStr());
+                                          assertEquals(TimeZone.getTimeZone("Europe/Paris"), stock.getQuote().getTimeZone());
+
+                                          assertEquals(new BigDecimal("-0.66"), stock.getQuote().getChange());
+                                          assertEquals(new BigDecimal("-1.29"), stock.getQuote().getChangeInPercent());
+                                          assertEquals(new BigDecimal("-1.47"), stock.getQuote().getChangeFromAvg50());
+                                          assertEquals(new BigDecimal("-2.84"), stock.getQuote().getChangeFromAvg50InPercent());
+                                          assertEquals(new BigDecimal("-4.87"), stock.getQuote().getChangeFromAvg200());
+                                          assertEquals(new BigDecimal("-8.82"), stock.getQuote().getChangeFromAvg200InPercent());
+                                          assertEquals(new BigDecimal("-18.16"), stock.getQuote().getChangeFromYearHigh());
+                                          assertEquals(new BigDecimal("-26.51"), stock.getQuote().getChangeFromYearHighInPercent());
+                                          assertEquals(new BigDecimal("2.27"), stock.getQuote().getChangeFromYearLow());
+                                          assertEquals(new BigDecimal("4.72"), stock.getQuote().getChangeFromYearLowInPercent());
+
+                                          assertEquals(new BigDecimal("38880000000.00"), stock.getStats().getMarketCap());
+                                          assertEquals(new Long(654166000), stock.getStats().getSharesFloat());
+                                          assertEquals(new Long(772397000), stock.getStats().getSharesOutstanding());
+                                          assertEquals(new BigDecimal("3.74"), stock.getStats().getEps());
+                                          assertEquals(new BigDecimal("13.47"), stock.getStats().getPe());
+                                          assertEquals(new BigDecimal("0.00"), stock.getStats().getPeg());
+                                          assertEquals(new BigDecimal("0.83"), stock.getStats().getEpsEstimateCurrentYear());
+                                          assertEquals(new BigDecimal("0.00"), stock.getStats().getEpsEstimateNextQuarter());
+                                          assertNull(stock.getStats().getEpsEstimateNextYear());
+                                          assertEquals(new BigDecimal("6.51"), stock.getStats().getPriceBook());
+                                          assertEquals(new BigDecimal("0.61"), stock.getStats().getPriceSales());
+                                          assertEquals(new BigDecimal("7.84"), stock.getStats().getBookValuePerShare());
+                                          assertEquals(new BigDecimal("64310000000.00"), stock.getStats().getRevenue());
+                                          assertEquals(new BigDecimal("4800000000.00"), stock.getStats().getEBITDA());
+                                          assertNull(stock.getStats().getOneYearTargetPrice());
+                                          assertEquals(new BigDecimal("0.00"), stock.getStats().getShortRatio());
+
+                                          assertNull(stock.getDividend().getPayDate());
+                                          assertNull(stock.getDividend().getAnnualYield());
+                                          assertNull(stock.getDividend().getAnnualYieldPercent());
+                                          assertEquals(4, stock.getDividend().getExDate().get(Calendar.MONTH));
+                                          assertEquals(2, stock.getDividend().getExDate().get(Calendar.DAY_OF_MONTH));
+                                      }
+                                  });
+    }
+
+    @Test
+    public void usStockQuoteTest() throws IOException {
+        Observable<Stock> stockObservable = YahooFinance.getRx("INTC");
+        stockObservable.subscribe(new Action1<Stock>() {
+            @Override
+            public void call(Stock stock) {
+                assertEquals("INTC", stock.getSymbol());
+                assertEquals("Intel Corporation", stock.getName());
+                assertEquals("USD", stock.getCurrency());
+                assertEquals("NMS", stock.getStockExchange());
+
+                assertNotNull(stock.getQuote());
+                assertNotNull(stock.getStats());
+                assertNotNull(stock.getDividend());
+
+                /*
+                 * Just check a few to make sure everything is fine
+                 * Most things already tested by europeanStockQuoteTest
+                 */
+                assertEquals(new BigDecimal("35.03"), stock.getQuote().getAsk());
+                assertEquals(new Long(1699919), stock.getQuote().getLastTradeSize());
+                assertEquals(new BigDecimal("34.98"), stock.getQuote().getPreviousClose());
+                assertEquals(new BigDecimal("35.93"), stock.getQuote().getYearHigh());
+
+                assertEquals(new BigDecimal("2.80"), stock.getStats().getPeg());
+                assertEquals(new BigDecimal("37.61"), stock.getStats().getOneYearTargetPrice());
+                assertEquals(new BigDecimal("2.94"), stock.getStats().getShortRatio());
+
+                assertEquals(5, stock.getDividend().getPayDate().get(Calendar.MONTH));
+                assertEquals(1, stock.getDividend().getPayDate().get(Calendar.DAY_OF_MONTH));
+                assertEquals(7, stock.getDividend().getExDate().get(Calendar.MONTH));
+                assertEquals(3, stock.getDividend().getExDate().get(Calendar.DAY_OF_MONTH));
+                assertEquals(new BigDecimal("1.04"), stock.getDividend().getAnnualYield());
+                assertEquals(new BigDecimal("2.97"), stock.getDividend().getAnnualYieldPercent());
+            }
+        });
+    }
+
+    @Test
+    public void singaporeStockQuoteTest() throws IOException {
+        YahooFinance.getRx("C6L.SI").subscribe(new Action1<Stock>() {
+            @Override
+            public void call(Stock stock) {
+                assertEquals("C6L.SI", stock.getSymbol());
+                assertEquals("SIA", stock.getName());
+                assertEquals("SGD", stock.getCurrency());
+                assertEquals("SES", stock.getStockExchange());
+
+                assertNotNull(stock.getQuote());
+                assertNotNull(stock.getStats());
+                assertNotNull(stock.getDividend());
+
+                assertEquals(new BigDecimal("10.89"), stock.getQuote().getAsk());
+                assertEquals(new Long(300), stock.getQuote().getLastTradeSize());
+                assertEquals(new BigDecimal("10.84"), stock.getQuote().getPreviousClose());
+                assertEquals(new BigDecimal("9.57"), stock.getQuote().getYearLow());
+
+                assertEquals(new BigDecimal("0.00"), stock.getStats().getPeg());
+                assertEquals(new BigDecimal("0.82"), stock.getStats().getEps());
+                assertEquals(new BigDecimal("11.44"), stock.getStats().getBookValuePerShare());
+                assertNull(stock.getStats().getOneYearTargetPrice());
+                assertEquals(new BigDecimal("0.00"), stock.getStats().getShortRatio());
+
+                assertEquals(7, stock.getDividend().getExDate().get(Calendar.MONTH));
+                assertEquals(2, stock.getDividend().getExDate().get(Calendar.DAY_OF_MONTH));
+                assertNull(stock.getDividend().getAnnualYield());
+                assertNull(stock.getDividend().getAnnualYieldPercent());
+            }
+        });
+    }
+
+}


### PR DESCRIPTION
I am looking into using this library in an Android application, which does not allow for network access on the main thread. I've added RxJava support for an easy way to execute the network calls on a background thread.

Each get method in YahooFinance.java has a getRx method that returns an Observable<Stock>.

I also copied and modified SimpleQuoteRequestTest to use the getRx methods.
