### PR TITLE
Use slf4j for logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,17 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.slf4j </groupId>
+            <artifactId>slf4j-api </artifactId>
+            <version>1.7.25</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j </groupId>
+            <artifactId>slf4j-simple </artifactId>
+            <version>1.7.25</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>

--- a/src/main/java/yahoofinance/Stock.java
+++ b/src/main/java/yahoofinance/Stock.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Calendar;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import yahoofinance.histquotes.HistQuotesRequest;
 import yahoofinance.histquotes.HistoricalQuote;
 import yahoofinance.histquotes.Interval;
@@ -22,6 +24,8 @@ import yahoofinance.quotes.stock.StockStats;
  */
 public class Stock {
 
+    private static final Logger log = LoggerFactory.getLogger(Stock.class);
+  
     private final String symbol;
     private String name;
     private String currency;
@@ -44,9 +48,9 @@ public class Stock {
             this.setQuote(data.getQuote());
             this.setStats(data.getStats());
             this.setDividend(data.getDividend());
-            YahooFinance.logger.log(Level.INFO, "Updated Stock with symbol: {0}", this.symbol);
+            log.info("Updated Stock with symbol: {}", this.symbol);
         } else {
-            YahooFinance.logger.log(Level.SEVERE, "Failed to update Stock with symbol: {0}", this.symbol);
+            log.error("Failed to update Stock with symbol: {}", this.symbol);
         }
     }
 
@@ -364,9 +368,9 @@ public class Stock {
             try {
                 System.out.println(f.getName() + ": " + f.get(this));
             } catch (IllegalArgumentException ex) {
-                Logger.getLogger(Stock.class.getName()).log(Level.SEVERE, null, ex);
+                log.error(null, ex);
             } catch (IllegalAccessException ex) {
-                Logger.getLogger(Stock.class.getName()).log(Level.SEVERE, null, ex);
+                log.error(null, ex);
             }
         }
         System.out.println("--------------------------------");

--- a/src/main/java/yahoofinance/Utils.java
+++ b/src/main/java/yahoofinance/Utils.java
@@ -10,7 +10,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TimeZone;
-import java.util.logging.Level;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -18,6 +20,8 @@ import java.util.logging.Level;
  */
 public class Utils {
 
+    private static final Logger log = LoggerFactory.getLogger(Utils.class);
+  
     public static final BigDecimal HUNDRED = new BigDecimal(100);
     public static final BigDecimal THOUSAND = new BigDecimal(1000);
     public static final BigDecimal MILLION = new BigDecimal(1000000);
@@ -77,8 +81,8 @@ public class Utils {
             }
             result = new BigDecimal(data).multiply(multiplier);
         } catch (NumberFormatException e) {
-            YahooFinance.logger.log(Level.WARNING, "Failed to parse: " + data);
-            YahooFinance.logger.log(Level.FINEST, "Failed to parse: " + data, e);
+            log.warn("Failed to parse: " + data);
+            log.debug("Failed to parse: " + data, e);
         }
         return result;
     }
@@ -117,8 +121,8 @@ public class Utils {
             }
             result = Double.parseDouble(data) * multiplier;
         } catch (NumberFormatException e) {
-            YahooFinance.logger.log(Level.WARNING, "Failed to parse: " + data);
-            YahooFinance.logger.log(Level.FINEST, "Failed to parse: " + data, e);
+            log.warn("Failed to parse: " + data);
+            log.debug("Failed to parse: " + data, e);
         }
         return result;
     }
@@ -132,8 +136,8 @@ public class Utils {
             data = Utils.cleanNumberString(data);
             result = Integer.parseInt(data);
         } catch (NumberFormatException e) {
-            YahooFinance.logger.log(Level.WARNING, "Failed to parse: " + data);
-            YahooFinance.logger.log(Level.FINEST, "Failed to parse: " + data, e);
+            log.warn("Failed to parse: " + data);
+            log.debug("Failed to parse: " + data, e);
         }
         return result;
     }
@@ -147,8 +151,8 @@ public class Utils {
             data = Utils.cleanNumberString(data);
             result = Long.parseLong(data);
         } catch (NumberFormatException e) {
-            YahooFinance.logger.log(Level.WARNING, "Failed to parse: " + data);
-            YahooFinance.logger.log(Level.FINEST, "Failed to parse: " + data, e);
+            log.warn("Failed to parse: " + data);
+            log.debug("Failed to parse: " + data, e);
         }
         return result;
     }
@@ -213,8 +217,8 @@ public class Utils {
 
             return parsedDate;
         } catch (ParseException ex) {
-            YahooFinance.logger.log(Level.WARNING, "Failed to parse dividend date: " + date);
-            YahooFinance.logger.log(Level.FINEST, "Failed to parse dividend date: " + date, ex);
+            log.warn("Failed to parse dividend date: " + date);
+            log.debug("Failed to parse dividend date: " + date, ex);
             return null;
         }
     }
@@ -240,8 +244,8 @@ public class Utils {
                 return c;
             }
         } catch (ParseException ex) {
-            YahooFinance.logger.log(Level.WARNING, "Failed to parse datetime: " + datetime);
-            YahooFinance.logger.log(Level.FINEST, "Failed to parse datetime: " + datetime, ex);
+            log.warn("Failed to parse datetime: " + datetime);
+            log.debug("Failed to parse datetime: " + datetime, ex);
         }
         return null;
     }
@@ -255,8 +259,8 @@ public class Utils {
                 return c;
             }
         } catch (ParseException ex) {
-            YahooFinance.logger.log(Level.WARNING, "Failed to parse hist date: " + date);
-            YahooFinance.logger.log(Level.FINEST, "Failed to parse hist date: " + date, ex);
+            log.warn("Failed to parse hist date: " + date);
+            log.debug("Failed to parse hist date: " + date, ex);
         }
         return null;
     }
@@ -274,7 +278,7 @@ public class Utils {
                 key = URLEncoder.encode(key, "UTF-8");
                 value = URLEncoder.encode(value, "UTF-8");
             } catch (UnsupportedEncodingException ex) {
-                YahooFinance.logger.log(Level.SEVERE, ex.getMessage(), ex);
+                log.error(ex.getMessage(), ex);
                 // Still try to continue with unencoded values
             }
             sb.append(String.format("%s=%s", key, value));

--- a/src/main/java/yahoofinance/YahooFinance.java
+++ b/src/main/java/yahoofinance/YahooFinance.java
@@ -1,4 +1,3 @@
-
 package yahoofinance;
 
 import java.io.IOException;
@@ -6,7 +5,6 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
 import yahoofinance.histquotes.HistQuotesRequest;
 import yahoofinance.histquotes.Interval;
 import yahoofinance.quotes.fx.FxQuote;
@@ -57,8 +55,6 @@ public class YahooFinance {
     
     public static final int CONNECTION_TIMEOUT = 
             Integer.parseInt(System.getProperty("yahoofinance.connection.timeout", "10000"));
-    
-    public static final Logger logger = Logger.getLogger(YahooFinance.class.getName());
     
     /**
     * Sends a basic quotes request to Yahoo Finance. This will return a {@link Stock} object

--- a/src/main/java/yahoofinance/exchanges/ExchangeTimeZone.java
+++ b/src/main/java/yahoofinance/exchanges/ExchangeTimeZone.java
@@ -4,16 +4,18 @@ package yahoofinance.exchanges;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
-import java.util.logging.Level;
-import yahoofinance.YahooFinance;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
  * @author Stijn Strickx
  */
 public class ExchangeTimeZone {
-    
-    
+
+    private static final Logger log = LoggerFactory.getLogger(ExchangeTimeZone.class);
+
     public static final Map<String, TimeZone> SUFFIX_TIMEZONES = new HashMap<String, TimeZone>();
     public static final Map<String, TimeZone> INDEX_TIMEZONES = new HashMap<String, TimeZone>();
     
@@ -163,12 +165,11 @@ public class ExchangeTimeZone {
      * @param suffix suffix for the exchange in YahooFinance
      * @return time zone of the exchange
      */
-    @SuppressWarnings("LoggerStringConcat")
     public static TimeZone get(String suffix) {
         if(SUFFIX_TIMEZONES.containsKey(suffix)) {
             return SUFFIX_TIMEZONES.get(suffix);
         }
-        YahooFinance.logger.log(Level.WARNING, "Cannot find time zone for exchange suffix: '" + suffix + "'. Using default: America/New_York");
+        log.warn("Cannot find time zone for exchange suffix: '{}'. Using default: America/New_York", suffix);
         return SUFFIX_TIMEZONES.get("");
     }
     

--- a/src/main/java/yahoofinance/histquotes/HistQuotesRequest.java
+++ b/src/main/java/yahoofinance/histquotes/HistQuotesRequest.java
@@ -11,7 +11,10 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import yahoofinance.Utils;
 import yahoofinance.YahooFinance;
 import yahoofinance.util.RedirectableRequest;
@@ -22,6 +25,7 @@ import yahoofinance.util.RedirectableRequest;
  */
 public class HistQuotesRequest {
 
+    private static final Logger log = LoggerFactory.getLogger(HistQuotesRequest.class);
     private final String symbol;
 
     private final Calendar from;
@@ -85,7 +89,7 @@ public class HistQuotesRequest {
         List<HistoricalQuote> result = new ArrayList<HistoricalQuote>();
         
         if(this.from.after(this.to)) {
-            YahooFinance.logger.log(Level.WARNING, "Unable to retrieve historical quotes. "
+            log.warn("Unable to retrieve historical quotes. "
                     + "From-date should not be after to-date. From: "
                     + this.from.getTime() + ", to: " + this.to.getTime());
             return result;
@@ -109,7 +113,7 @@ public class HistQuotesRequest {
         String url = YahooFinance.HISTQUOTES_BASE_URL + "?" + Utils.getURLParameters(params);
 
         // Get CSV from Yahoo
-        YahooFinance.logger.log(Level.INFO, ("Sending request: " + url));
+        log.info("Sending request: " + url);
 
         URL request = new URL(url);
         RedirectableRequest redirectableRequest = new RedirectableRequest(request, 5);
@@ -123,7 +127,7 @@ public class HistQuotesRequest {
         // Parse CSV
         for (String line = br.readLine(); line != null; line = br.readLine()) {
 
-            YahooFinance.logger.log(Level.INFO, ("Parsing CSV line: " + Utils.unescape(line)));
+            log.info("Parsing CSV line: " + Utils.unescape(line));
             HistoricalQuote quote = this.parseCSVLine(line);
             result.add(quote);
         }

--- a/src/main/java/yahoofinance/histquotes2/CrumbManager.java
+++ b/src/main/java/yahoofinance/histquotes2/CrumbManager.java
@@ -1,30 +1,33 @@
 package yahoofinance.histquotes2;
 
-import yahoofinance.YahooFinance;
-import yahoofinance.util.RedirectableRequest;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import yahoofinance.YahooFinance;
+import yahoofinance.util.RedirectableRequest;
 
 /**
  * Created by Stijn on 23/05/2017.
  */
 public class CrumbManager {
 
+    private static final Logger log = LoggerFactory.getLogger(CrumbManager.class);
+  
     private static String crumb = "";
     private static String cookie = "";
 
     private static void setCookie() throws IOException {
         if(YahooFinance.HISTQUOTES2_COOKIE != null && !YahooFinance.HISTQUOTES2_COOKIE.isEmpty()) {
             cookie = YahooFinance.HISTQUOTES2_COOKIE;
-            YahooFinance.logger.log(Level.FINE, "Set cookie from system property: " + cookie);
+            log.debug("Set cookie from system property: {}", cookie);
             return;
         }
 
@@ -40,20 +43,20 @@ public class CrumbManager {
                     for(String cookieValue : cookieField.split(";")) {
                         if(cookieValue.matches("B=.*")) {
                             cookie = cookieValue;
-                            YahooFinance.logger.log(Level.FINE, "Set cookie from http request: " + cookie);
+                            log.debug("Set cookie from http request: {}", cookie);
                             return;
                         }
                     }
                 }
             }
         }
-        YahooFinance.logger.log(Level.WARNING, "Failed to set cookie from http request. Historical quote requests will most likely fail.");
+        log.warn("Failed to set cookie from http request. Historical quote requests will most likely fail.");
     }
 
     private static void setCrumb() throws IOException {
         if(YahooFinance.HISTQUOTES2_CRUMB != null && !YahooFinance.HISTQUOTES2_CRUMB.isEmpty()) {
             crumb = YahooFinance.HISTQUOTES2_CRUMB;
-            YahooFinance.logger.log(Level.FINE, "Set crumb from system property: " + crumb);
+            log.debug("Set crumb from system property: {}", crumb);
             return;
         }
 
@@ -73,9 +76,9 @@ public class CrumbManager {
 
         if(crumbResult != null && !crumbResult.isEmpty()) {
             crumb = crumbResult.trim();
-            YahooFinance.logger.log(Level.FINE, "Set crumb from http request: " + crumb);
+            log.debug("Set crumb from http request: {}", crumb);
         } else {
-            YahooFinance.logger.log(Level.WARNING, "Failed to set crumb from http request. Historical quote requests will most likely fail.");
+            log.warn("Failed to set crumb from http request. Historical quote requests will most likely fail.");
         }
     }
 

--- a/src/main/java/yahoofinance/histquotes2/HistQuotes2Request.java
+++ b/src/main/java/yahoofinance/histquotes2/HistQuotes2Request.java
@@ -13,7 +13,9 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.util.*;
-import java.util.logging.Level;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -21,6 +23,8 @@ import java.util.logging.Level;
  */
 public class HistQuotes2Request {
 
+
+    private static final Logger log = LoggerFactory.getLogger(HistQuotes2Request.class);
     private final String symbol;
 
     private final Calendar from;
@@ -98,7 +102,7 @@ public class HistQuotes2Request {
         List<HistoricalQuote> result = new ArrayList<HistoricalQuote>();
         
         if(this.from.after(this.to)) {
-            YahooFinance.logger.log(Level.WARNING, "Unable to retrieve historical quotes. "
+            log.warn("Unable to retrieve historical quotes. "
                     + "From-date should not be after to-date. From: "
                     + this.from.getTime() + ", to: " + this.to.getTime());
             return result;
@@ -115,7 +119,7 @@ public class HistQuotes2Request {
         String url = YahooFinance.HISTQUOTES2_BASE_URL + URLEncoder.encode(this.symbol , "UTF-8") + "?" + Utils.getURLParameters(params);
 
         // Get CSV from Yahoo
-        YahooFinance.logger.log(Level.INFO, ("Sending request: " + url));
+        log.info("Sending request: " + url);
 
         URL request = new URL(url);
         RedirectableRequest redirectableRequest = new RedirectableRequest(request, 5);
@@ -131,7 +135,7 @@ public class HistQuotes2Request {
         // Parse CSV
         for (String line = br.readLine(); line != null; line = br.readLine()) {
 
-            YahooFinance.logger.log(Level.INFO, ("Parsing CSV line: " + Utils.unescape(line)));
+            log.info("Parsing CSV line: " + Utils.unescape(line));
             HistoricalQuote quote = this.parseCSVLine(line);
             result.add(quote);
         }

--- a/src/main/java/yahoofinance/quotes/QuotesRequest.java
+++ b/src/main/java/yahoofinance/quotes/QuotesRequest.java
@@ -9,7 +9,10 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import yahoofinance.Utils;
 import yahoofinance.YahooFinance;
 import yahoofinance.util.RedirectableRequest;
@@ -21,6 +24,8 @@ import yahoofinance.util.RedirectableRequest;
  * quotes request
  */
 public abstract class QuotesRequest<T> {
+
+    private static final Logger log = LoggerFactory.getLogger(QuotesRequest.class);
 
     protected final String query;
     protected List<QuotesProperty> properties;
@@ -77,7 +82,7 @@ public abstract class QuotesRequest<T> {
         String url = YahooFinance.QUOTES_BASE_URL + "?" + Utils.getURLParameters(params);
 
         // Get CSV from Yahoo
-        YahooFinance.logger.log(Level.INFO, ("Sending request: " + url));
+        log.info("Sending request: " + url);
 
         URL request = new URL(url);
         RedirectableRequest redirectableRequest = new RedirectableRequest(request, 5);
@@ -91,9 +96,9 @@ public abstract class QuotesRequest<T> {
         // Parse CSV
         for (String line = br.readLine(); line != null; line = br.readLine()) {
             if (line.equals("Missing Symbols List.")) {
-                YahooFinance.logger.log(Level.SEVERE, "The requested symbol was not recognized by Yahoo Finance");
+                log.error("The requested symbol was not recognized by Yahoo Finance");
             } else {
-                YahooFinance.logger.log(Level.INFO, ("Parsing CSV line: " + Utils.unescape(line)));
+                log.info("Parsing CSV line: " + Utils.unescape(line));
 
                 T data = this.parseCSVLine(line);
                 result.add(data);

--- a/src/main/java/yahoofinance/util/RedirectableRequest.java
+++ b/src/main/java/yahoofinance/util/RedirectableRequest.java
@@ -1,7 +1,5 @@
 package yahoofinance.util;
 
-import yahoofinance.YahooFinance;
-
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;

--- a/src/test/java/yahoofinance/mock/MockedServersTest.java
+++ b/src/test/java/yahoofinance/mock/MockedServersTest.java
@@ -2,13 +2,12 @@ package yahoofinance.mock;
 
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockWebServer;
-import org.junit.AfterClass;
-import org.junit.Before;
+
 import org.junit.BeforeClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  *
@@ -16,7 +15,7 @@ import java.util.logging.Logger;
  */
 public class MockedServersTest {
 
-    public static final Logger LOG = Logger.getLogger(MockedServersTest.class.getName());
+    private static final Logger log = LoggerFactory.getLogger(MockedServersTest.class);
 
     private static boolean started = false;
 
@@ -35,7 +34,7 @@ public class MockedServersTest {
             quotesServer.start();
             histQuotesServer.start();
         } catch (IOException e) {
-            LOG.log(Level.SEVERE, "Unable to start mock web server", e);
+            log.error("Unable to start mock web server", e);
         }
         String quotesBaseUrl = "http://localhost:" + quotesServer.getPort() + "/d/quotes.csv";
         String histQuotesBaseUrl = "http://localhost:" + histQuotesServer.getPort() + "/table.csv";

--- a/src/test/java/yahoofinance/mock/ResponseResource.java
+++ b/src/test/java/yahoofinance/mock/ResponseResource.java
@@ -6,8 +6,9 @@ import okhttp3.mockwebserver.MockResponse;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -15,7 +16,7 @@ import java.util.logging.Logger;
  */
 public class ResponseResource {
 
-    public static final Logger LOG = Logger.getLogger(ResponseResource.class.getName());
+    private static final Logger log = LoggerFactory.getLogger(ResponseResource.class);
 
     private int responseCode;
     private String resource;
@@ -35,7 +36,7 @@ public class ResponseResource {
             String response = Resources.toString(url, Charsets.UTF_8);
             return new MockResponse().setBody(response).setResponseCode(this.responseCode);
         } catch (IOException e) {
-            LOG.log(Level.SEVERE, "Unable to read response from resource", e);
+            log.error("Unable to read response from resource", e);
         }
         return null;
     }

--- a/src/test/java/yahoofinance/mock/YahooFinanceDispatcher.java
+++ b/src/test/java/yahoofinance/mock/YahooFinanceDispatcher.java
@@ -5,14 +5,15 @@ import com.google.common.io.Resources;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  *
@@ -20,7 +21,7 @@ import java.util.logging.Logger;
  */
 public class YahooFinanceDispatcher extends Dispatcher {
 
-    public static final Logger LOG = Logger.getLogger(YahooFinanceDispatcher.class.getName());
+    private static final Logger log = LoggerFactory.getLogger(YahooFinanceDispatcher.class);
 
     private Map<String, ResponseResource> pathToResponseResource;
 
@@ -34,7 +35,7 @@ public class YahooFinanceDispatcher extends Dispatcher {
         if(this.pathToResponseResource.containsKey(request.getPath())) {
             return this.pathToResponseResource.get(request.getPath()).get();
         } else {
-            LOG.log(Level.WARNING, "Requested path not configured. Cannot provide MockResponse for " + request.getPath());
+            log.warn("Requested path not configured. Cannot provide MockResponse for " + request.getPath());
         }
         return null;
     }
@@ -46,7 +47,7 @@ public class YahooFinanceDispatcher extends Dispatcher {
             String requestsYaml = Resources.toString(Resources.getResource("requests.yml"), Charsets.UTF_8);
             requests = (Map<String, List<Map<String, Object>>>) yaml.load(requestsYaml);
         } catch (IOException e) {
-            LOG.log(Level.WARNING, "Unable to process requests.yml. No requests mocked.", e);
+            log.warn("Unable to process requests.yml. No requests mocked.", e);
             return;
         }
         for(Map<String, Object> request : requests.get("requests")) {


### PR DESCRIPTION
By using SLF4J, the user can plug in any logging frameworks he wants, including java.util.logging, but also logback, log4j, etc.

Also j.u.l parametrization is at least 10 times slower than SLF4J's which ends up making a noticeable difference.