### PR TITLE
Support different return types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <distributionManagement>
@@ -58,9 +58,15 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.slf4j </groupId>
-            <artifactId>slf4j-api </artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
             <version>1.7.25</version>
+        </dependency>
+        <dependency>
+            <groupId>tech.tablesaw</groupId>
+            <artifactId>tablesaw-core</artifactId>
+            <version>0.9.0</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.slf4j </groupId>

--- a/src/main/java/yahoofinance/AbstractStock.java
+++ b/src/main/java/yahoofinance/AbstractStock.java
@@ -1,0 +1,382 @@
+package yahoofinance;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Calendar;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import yahoofinance.histquotes.HistQuotesRequest;
+import yahoofinance.histquotes.Interval;
+import yahoofinance.histquotes2.HistQuotes2Request;
+import yahoofinance.quotes.stock.StockDividend;
+import yahoofinance.quotes.stock.StockQuote;
+import yahoofinance.quotes.stock.StockQuotesData;
+import yahoofinance.quotes.stock.StockQuotesRequest;
+import yahoofinance.quotes.stock.StockStats;
+
+/**
+ *
+ * @author Stijn Strickx
+ */
+public abstract class AbstractStock<T> {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractStock.class);
+  
+    protected final String symbol;
+    protected String name;
+    protected String currency;
+    protected String stockExchange;
+    
+    protected StockQuote quote;
+    protected StockStats stats;
+    private StockDividend dividend;
+    
+    protected T history;
+    
+    public AbstractStock(String symbol) {
+        this.symbol = symbol;
+    }
+    
+    private void update() throws IOException {
+        StockQuotesRequest request = new StockQuotesRequest(this.symbol);
+        StockQuotesData data = request.getSingleResult();
+        if(data != null) {
+            this.setQuote(data.getQuote());
+            this.setStats(data.getStats());
+            this.setDividend(data.getDividend());
+            log.info("Updated Stock with symbol: {}", this.symbol);
+        } else {
+            log.error("Failed to update Stock with symbol: {}", this.symbol);
+        }
+    }
+
+    /**
+     * Checks if the returned name is null. This probably means that the symbol was not recognized by Yahoo Finance.
+     * @return whether this stock's symbol is known by Yahoo Finance (true) or not (false)
+     */
+    public boolean isValid() {
+        return this.name != null;
+    }
+    
+    /**
+     * Returns the basic quotes data available for this stock.
+     * 
+     * @return      basic quotes data available for this stock
+     * @see         #getQuote(boolean) 
+     */
+    public StockQuote getQuote() {
+        return this.quote;
+    }
+    
+    /**
+     * Returns the basic quotes data available for this stock.
+     * This method will return null in the following situations:
+     * <ul>
+     * <li> the data hasn't been loaded yet
+     *      in a previous request and refresh is set to false.
+     * <li> refresh is true and the data cannot be retrieved from Yahoo Finance 
+     *      for whatever reason (symbol not recognized, no network connection, ...)
+     * </ul>
+     * <p>
+     * When the quote data gets refreshed, it will automatically also refresh
+     * the statistics and dividend data of the stock from Yahoo Finance 
+     * in the same request.
+     * 
+     * @param refresh   indicates whether the data should be requested again to Yahoo Finance
+     * @return          basic quotes data available for this stock
+     * @throws java.io.IOException when there's a connection problem
+     */
+    public StockQuote getQuote(boolean refresh) throws IOException {
+        if(refresh) {
+            this.update();
+        }
+        return this.quote;
+    }
+    
+    public void setQuote(StockQuote quote) {
+        this.quote = quote;
+    }
+    
+    /**
+     * Returns the statistics available for this stock.
+     * 
+     * @return      statistics available for this stock
+     * @see         #getStats(boolean) 
+     */
+    public StockStats getStats() {
+        return this.stats;
+    }
+    
+    /**
+     * Returns the statistics available for this stock.
+     * This method will return null in the following situations:
+     * <ul>
+     * <li> the data hasn't been loaded yet
+     *      in a previous request and refresh is set to false.
+     * <li> refresh is true and the data cannot be retrieved from Yahoo Finance 
+     *      for whatever reason (symbol not recognized, no network connection, ...)
+     * </ul>
+     * <p>
+     * When the statistics get refreshed, it will automatically also refresh
+     * the quote and dividend data of the stock from Yahoo Finance 
+     * in the same request.
+     * 
+     * @param refresh   indicates whether the data should be requested again to Yahoo Finance
+     * @return          statistics available for this stock
+     * @throws java.io.IOException when there's a connection problem
+     */
+    public StockStats getStats(boolean refresh) throws IOException {
+        if(refresh) {
+            this.update();
+        }
+        return this.stats;
+    }
+    
+    public void setStats(StockStats stats) {
+        this.stats = stats;
+    }
+    
+    /**
+     * Returns the dividend data available for this stock.
+     * 
+     * @return      dividend data available for this stock
+     * @see         #getDividend(boolean) 
+     */
+    public StockDividend getDividend() {
+        return this.dividend;
+    }
+    
+    /**
+     * Returns the dividend data available for this stock.
+     * 
+     * This method will return null in the following situations:
+     * <ul>
+     * <li> the data hasn't been loaded yet
+     *      in a previous request and refresh is set to false.
+     * <li> refresh is true and the data cannot be retrieved from Yahoo Finance 
+     *      for whatever reason (symbol not recognized, no network connection, ...)
+     * </ul>
+     * <p>
+     * When the dividend data get refreshed, it will automatically also refresh
+     * the quote and statistics data of the stock from Yahoo Finance 
+     * in the same request.
+     * 
+     * @param refresh   indicates whether the data should be requested again to Yahoo Finance
+     * @return          dividend data available for this stock
+     * @throws java.io.IOException when there's a connection problem
+     */
+    public StockDividend getDividend(boolean refresh) throws IOException {
+        if(refresh) {
+            this.update();
+        }
+        return this.dividend;
+    }
+    
+    public void setDividend(StockDividend dividend) {
+        this.dividend = dividend;
+    }
+    
+    /**
+     * This method will return historical quotes from this stock.
+     * If the historical quotes are not available yet, they will 
+     * be requested first from Yahoo Finance.
+     * <p>
+     * If the historical quotes are not available yet, the
+     * following characteristics will be used for the request:
+     * <ul>
+     * <li> from: 1 year ago (default)
+     * <li> to: today (default)
+     * <li> interval: MONTHLY (default)
+     * </ul>
+     * <p>
+     * There are several more methods available that allow you
+     * to define some characteristics of the historical data.
+     * Calling one of those methods will result in a new request
+     * being sent to Yahoo Finance.
+     * 
+     * @return      a list of historical quotes from this stock
+     * @throws java.io.IOException when there's a connection problem
+     * @see         #getHistory(yahoofinance.histquotes.Interval) 
+     * @see         #getHistory(java.util.Calendar) 
+     * @see         #getHistory(java.util.Calendar, java.util.Calendar) 
+     * @see         #getHistory(java.util.Calendar, yahoofinance.histquotes.Interval) 
+     * @see         #getHistory(java.util.Calendar, java.util.Calendar, yahoofinance.histquotes.Interval) 
+     */
+    public T getHistory() throws IOException {
+        if(this.history != null) {
+            return this.history;
+        }
+        return this.getHistory(HistQuotesRequest.DEFAULT_FROM);
+    }
+    
+    /**
+     * Requests the historical quotes for this stock with the following characteristics.
+     * <ul>
+     * <li> from: 1 year ago (default)
+     * <li> to: today (default)
+     * <li> interval: specified value
+     * </ul>
+     * 
+     * @param interval      the interval of the historical data
+     * @return              a list of historical quotes from this stock
+     * @throws java.io.IOException when there's a connection problem
+     * @see                 #getHistory() 
+     */
+    public T getHistory(Interval interval) throws IOException {
+        return this.getHistory(HistQuotesRequest.DEFAULT_FROM, interval);
+    }
+    
+    /**
+     * Requests the historical quotes for this stock with the following characteristics.
+     * <ul>
+     * <li> from: specified value
+     * <li> to: today (default)
+     * <li> interval: MONTHLY (default)
+     * </ul>
+     * 
+     * @param from          start date of the historical data
+     * @return              a list of historical quotes from this stock
+     * @throws java.io.IOException when there's a connection problem
+     * @see                 #getHistory() 
+     */
+    public T getHistory(Calendar from) throws IOException {
+        return this.getHistory(from, HistQuotesRequest.DEFAULT_TO);
+    }
+    
+    /**
+     * Requests the historical quotes for this stock with the following characteristics.
+     * <ul>
+     * <li> from: specified value
+     * <li> to: today (default)
+     * <li> interval: specified value
+     * </ul>
+     * 
+     * @param from          start date of the historical data
+     * @param interval      the interval of the historical data
+     * @return              a list of historical quotes from this stock
+     * @throws java.io.IOException when there's a connection problem
+     * @see                 #getHistory() 
+     */
+    public T getHistory(Calendar from, Interval interval) throws IOException {
+        return this.getHistory(from, HistQuotesRequest.DEFAULT_TO, interval);
+    }
+    
+    /**
+     * Requests the historical quotes for this stock with the following characteristics.
+     * <ul>
+     * <li> from: specified value
+     * <li> to: specified value
+     * <li> interval: MONTHLY (default)
+     * </ul>
+     * 
+     * @param from          start date of the historical data
+     * @param to            end date of the historical data
+     * @return              a list of historical quotes from this stock
+     * @throws java.io.IOException when there's a connection problem
+     * @see                 #getHistory() 
+     */
+    public T getHistory(Calendar from, Calendar to) throws IOException {
+        return this.getHistory(from, to, Interval.MONTHLY);
+    }
+
+    protected String getHistoryAsString(Calendar from, Calendar to, Interval interval) throws IOException {
+      if(YahooFinance.HISTQUOTES2_ENABLED.equalsIgnoreCase("true")) {
+          return new HistQuotes2Request(this.symbol, from, to, interval).getResult();
+      } else {
+          return new HistQuotesRequest(this.symbol, from, to, interval).getResult();
+      }
+    }
+
+    protected abstract T transform(String csv);
+    
+    /**
+     * Requests the historical quotes for this stock with the following characteristics.
+     * <ul>
+     * <li> from: specified value
+     * <li> to: specified value
+     * <li> interval: specified value
+     * </ul>
+     * 
+     * @param from          start date of the historical data
+     * @param to            end date of the historical data
+     * @param interval      the interval of the historical data
+     * @return              a list of historical quotes from this stock
+     * @throws java.io.IOException when there's a connection problem
+     * @see                 #getHistory() 
+     */
+    public T getHistory(Calendar from, Calendar to, Interval interval) throws IOException {
+        String historyCsv = getHistoryAsString(from, to, interval);
+        this.setHistory(transform(historyCsv));
+        return this.history;
+    }
+    
+    void setHistory(T history) {
+        this.history = history;
+    }
+    
+    public String getSymbol() {
+        return symbol;
+    }
+    
+    /**
+     * Get the full name of the stock
+     * 
+     * @return the name or null if the data is not available
+     */
+    public String getName() {
+        return name;
+    }
+    
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+    /**
+     * Get the currency of the stock
+     * 
+     * @return the currency or null if the data is not available
+     */
+    public String getCurrency() {
+        return currency;
+    }
+    
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+    
+    /**
+     * Get the exchange on which the stock is traded
+     * 
+     * @return the exchange or null if the data is not available
+     */
+    public String getStockExchange() {
+        return stockExchange;
+    }
+    
+    public void setStockExchange(String stockExchange) {
+        this.stockExchange = stockExchange;
+    }
+    
+    @Override
+    public String toString() {
+        return this.symbol + ": " + this.quote.getPrice();
+    }
+    
+    public void print() {
+        System.out.println(this.symbol);
+        System.out.println("--------------------------------");
+        for (Field f : this.getClass().getDeclaredFields()) {
+            try {
+                System.out.println(f.getName() + ": " + f.get(this));
+            } catch (IllegalArgumentException ex) {
+                log.error(null, ex);
+            } catch (IllegalAccessException ex) {
+                log.error(null, ex);
+            }
+        }
+        System.out.println("--------------------------------");
+    }
+    
+}

--- a/src/main/java/yahoofinance/CsvStock.java
+++ b/src/main/java/yahoofinance/CsvStock.java
@@ -1,0 +1,17 @@
+package yahoofinance;
+
+/**
+ * @author Stijn Strickx
+ */
+public class CsvStock extends AbstractStock<String> {
+
+    public CsvStock(String symbol) {
+        super(symbol);
+    }
+
+    @Override
+    protected String transform(String csv) {
+      return csv;
+    }
+
+}

--- a/src/main/java/yahoofinance/Stock.java
+++ b/src/main/java/yahoofinance/Stock.java
@@ -1,379 +1,53 @@
 package yahoofinance;
 
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.util.Calendar;
+import java.util.ArrayList;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import yahoofinance.histquotes.HistQuotesRequest;
 import yahoofinance.histquotes.HistoricalQuote;
-import yahoofinance.histquotes.Interval;
-import yahoofinance.histquotes2.HistQuotes2Request;
-import yahoofinance.quotes.stock.StockDividend;
-import yahoofinance.quotes.stock.StockQuote;
-import yahoofinance.quotes.stock.StockQuotesData;
-import yahoofinance.quotes.stock.StockQuotesRequest;
-import yahoofinance.quotes.stock.StockStats;
 
 /**
- *
  * @author Stijn Strickx
  */
-public class Stock {
+public class Stock extends AbstractStock<List<HistoricalQuote>> {
 
-    private static final Logger log = LoggerFactory.getLogger(Stock.class);
-  
-    private final String symbol;
-    private String name;
-    private String currency;
-    private String stockExchange;
-    
-    private StockQuote quote;
-    private StockStats stats;
-    private StockDividend dividend;
-    
-    private List<HistoricalQuote> history;
-    
-    public Stock(String symbol) {
-        this.symbol = symbol;
-    }
-    
-    private void update() throws IOException {
-        StockQuotesRequest request = new StockQuotesRequest(this.symbol);
-        StockQuotesData data = request.getSingleResult();
-        if(data != null) {
-            this.setQuote(data.getQuote());
-            this.setStats(data.getStats());
-            this.setDividend(data.getDividend());
-            log.info("Updated Stock with symbol: {}", this.symbol);
-        } else {
-            log.error("Failed to update Stock with symbol: {}", this.symbol);
-        }
-    }
+  public Stock(String symbol) {
+    super(symbol);
+  }
 
-    /**
-     * Checks if the returned name is null. This probably means that the symbol was not recognized by Yahoo Finance.
-     * @return whether this stock's symbol is known by Yahoo Finance (true) or not (false)
-     */
-    public boolean isValid() {
-        return this.name != null;
+  @Override
+  protected List<HistoricalQuote> transform(String csv) {
+    String[] lines = csv.split("\\r?\\n");
+    List<HistoricalQuote> quotes = new ArrayList<>();
+    for (int i = 1; i < lines.length; i++) {
+      quotes.add(YahooFinance.HISTQUOTES2_ENABLED.equalsIgnoreCase("true")
+          ? parseCSVLine2(lines[i]) : parseCSVLine(lines[i]));
     }
-    
-    /**
-     * Returns the basic quotes data available for this stock.
-     * 
-     * @return      basic quotes data available for this stock
-     * @see         #getQuote(boolean) 
-     */
-    public StockQuote getQuote() {
-        return this.quote;
-    }
-    
-    /**
-     * Returns the basic quotes data available for this stock.
-     * This method will return null in the following situations:
-     * <ul>
-     * <li> the data hasn't been loaded yet
-     *      in a previous request and refresh is set to false.
-     * <li> refresh is true and the data cannot be retrieved from Yahoo Finance 
-     *      for whatever reason (symbol not recognized, no network connection, ...)
-     * </ul>
-     * <p>
-     * When the quote data gets refreshed, it will automatically also refresh
-     * the statistics and dividend data of the stock from Yahoo Finance 
-     * in the same request.
-     * 
-     * @param refresh   indicates whether the data should be requested again to Yahoo Finance
-     * @return          basic quotes data available for this stock
-     * @throws java.io.IOException when there's a connection problem
-     */
-    public StockQuote getQuote(boolean refresh) throws IOException {
-        if(refresh) {
-            this.update();
-        }
-        return this.quote;
-    }
-    
-    public void setQuote(StockQuote quote) {
-        this.quote = quote;
-    }
-    
-    /**
-     * Returns the statistics available for this stock.
-     * 
-     * @return      statistics available for this stock
-     * @see         #getStats(boolean) 
-     */
-    public StockStats getStats() {
-        return this.stats;
-    }
-    
-    /**
-     * Returns the statistics available for this stock.
-     * This method will return null in the following situations:
-     * <ul>
-     * <li> the data hasn't been loaded yet
-     *      in a previous request and refresh is set to false.
-     * <li> refresh is true and the data cannot be retrieved from Yahoo Finance 
-     *      for whatever reason (symbol not recognized, no network connection, ...)
-     * </ul>
-     * <p>
-     * When the statistics get refreshed, it will automatically also refresh
-     * the quote and dividend data of the stock from Yahoo Finance 
-     * in the same request.
-     * 
-     * @param refresh   indicates whether the data should be requested again to Yahoo Finance
-     * @return          statistics available for this stock
-     * @throws java.io.IOException when there's a connection problem
-     */
-    public StockStats getStats(boolean refresh) throws IOException {
-        if(refresh) {
-            this.update();
-        }
-        return this.stats;
-    }
-    
-    public void setStats(StockStats stats) {
-        this.stats = stats;
-    }
-    
-    /**
-     * Returns the dividend data available for this stock.
-     * 
-     * @return      dividend data available for this stock
-     * @see         #getDividend(boolean) 
-     */
-    public StockDividend getDividend() {
-        return this.dividend;
-    }
-    
-    /**
-     * Returns the dividend data available for this stock.
-     * 
-     * This method will return null in the following situations:
-     * <ul>
-     * <li> the data hasn't been loaded yet
-     *      in a previous request and refresh is set to false.
-     * <li> refresh is true and the data cannot be retrieved from Yahoo Finance 
-     *      for whatever reason (symbol not recognized, no network connection, ...)
-     * </ul>
-     * <p>
-     * When the dividend data get refreshed, it will automatically also refresh
-     * the quote and statistics data of the stock from Yahoo Finance 
-     * in the same request.
-     * 
-     * @param refresh   indicates whether the data should be requested again to Yahoo Finance
-     * @return          dividend data available for this stock
-     * @throws java.io.IOException when there's a connection problem
-     */
-    public StockDividend getDividend(boolean refresh) throws IOException {
-        if(refresh) {
-            this.update();
-        }
-        return this.dividend;
-    }
-    
-    public void setDividend(StockDividend dividend) {
-        this.dividend = dividend;
-    }
-    
-    /**
-     * This method will return historical quotes from this stock.
-     * If the historical quotes are not available yet, they will 
-     * be requested first from Yahoo Finance.
-     * <p>
-     * If the historical quotes are not available yet, the
-     * following characteristics will be used for the request:
-     * <ul>
-     * <li> from: 1 year ago (default)
-     * <li> to: today (default)
-     * <li> interval: MONTHLY (default)
-     * </ul>
-     * <p>
-     * There are several more methods available that allow you
-     * to define some characteristics of the historical data.
-     * Calling one of those methods will result in a new request
-     * being sent to Yahoo Finance.
-     * 
-     * @return      a list of historical quotes from this stock
-     * @throws java.io.IOException when there's a connection problem
-     * @see         #getHistory(yahoofinance.histquotes.Interval) 
-     * @see         #getHistory(java.util.Calendar) 
-     * @see         #getHistory(java.util.Calendar, java.util.Calendar) 
-     * @see         #getHistory(java.util.Calendar, yahoofinance.histquotes.Interval) 
-     * @see         #getHistory(java.util.Calendar, java.util.Calendar, yahoofinance.histquotes.Interval) 
-     */
-    public List<HistoricalQuote> getHistory() throws IOException {
-        if(this.history != null) {
-            return this.history;
-        }
-        return this.getHistory(HistQuotesRequest.DEFAULT_FROM);
-    }
-    
-    /**
-     * Requests the historical quotes for this stock with the following characteristics.
-     * <ul>
-     * <li> from: 1 year ago (default)
-     * <li> to: today (default)
-     * <li> interval: specified value
-     * </ul>
-     * 
-     * @param interval      the interval of the historical data
-     * @return              a list of historical quotes from this stock
-     * @throws java.io.IOException when there's a connection problem
-     * @see                 #getHistory() 
-     */
-    public List<HistoricalQuote> getHistory(Interval interval) throws IOException {
-        return this.getHistory(HistQuotesRequest.DEFAULT_FROM, interval);
-    }
-    
-    /**
-     * Requests the historical quotes for this stock with the following characteristics.
-     * <ul>
-     * <li> from: specified value
-     * <li> to: today (default)
-     * <li> interval: MONTHLY (default)
-     * </ul>
-     * 
-     * @param from          start date of the historical data
-     * @return              a list of historical quotes from this stock
-     * @throws java.io.IOException when there's a connection problem
-     * @see                 #getHistory() 
-     */
-    public List<HistoricalQuote> getHistory(Calendar from) throws IOException {
-        return this.getHistory(from, HistQuotesRequest.DEFAULT_TO);
-    }
-    
-    /**
-     * Requests the historical quotes for this stock with the following characteristics.
-     * <ul>
-     * <li> from: specified value
-     * <li> to: today (default)
-     * <li> interval: specified value
-     * </ul>
-     * 
-     * @param from          start date of the historical data
-     * @param interval      the interval of the historical data
-     * @return              a list of historical quotes from this stock
-     * @throws java.io.IOException when there's a connection problem
-     * @see                 #getHistory() 
-     */
-    public List<HistoricalQuote> getHistory(Calendar from, Interval interval) throws IOException {
-        return this.getHistory(from, HistQuotesRequest.DEFAULT_TO, interval);
-    }
-    
-    /**
-     * Requests the historical quotes for this stock with the following characteristics.
-     * <ul>
-     * <li> from: specified value
-     * <li> to: specified value
-     * <li> interval: MONTHLY (default)
-     * </ul>
-     * 
-     * @param from          start date of the historical data
-     * @param to            end date of the historical data
-     * @return              a list of historical quotes from this stock
-     * @throws java.io.IOException when there's a connection problem
-     * @see                 #getHistory() 
-     */
-    public List<HistoricalQuote> getHistory(Calendar from, Calendar to) throws IOException {
-        return this.getHistory(from, to, Interval.MONTHLY);
-    }
-    
-    /**
-     * Requests the historical quotes for this stock with the following characteristics.
-     * <ul>
-     * <li> from: specified value
-     * <li> to: specified value
-     * <li> interval: specified value
-     * </ul>
-     * 
-     * @param from          start date of the historical data
-     * @param to            end date of the historical data
-     * @param interval      the interval of the historical data
-     * @return              a list of historical quotes from this stock
-     * @throws java.io.IOException when there's a connection problem
-     * @see                 #getHistory() 
-     */
-    public List<HistoricalQuote> getHistory(Calendar from, Calendar to, Interval interval) throws IOException {
-        if(YahooFinance.HISTQUOTES2_ENABLED.equalsIgnoreCase("true")) {
-            HistQuotes2Request hist = new HistQuotes2Request(this.symbol, from, to, interval);
-            this.setHistory(hist.getResult());
-        } else {
-            HistQuotesRequest hist = new HistQuotesRequest(this.symbol, from, to, interval);
-            this.setHistory(hist.getResult());
-        }
-        return this.history;
-    }
-    
-    public void setHistory(List<HistoricalQuote> history) {
-        this.history = history;
-    }
-    
-    public String getSymbol() {
-        return symbol;
-    }
-    
-    /**
-     * Get the full name of the stock
-     * 
-     * @return the name or null if the data is not available
-     */
-    public String getName() {
-        return name;
-    }
-    
-    public void setName(String name) {
-        this.name = name;
-    }
-    
-    /**
-     * Get the currency of the stock
-     * 
-     * @return the currency or null if the data is not available
-     */
-    public String getCurrency() {
-        return currency;
-    }
-    
-    public void setCurrency(String currency) {
-        this.currency = currency;
-    }
-    
-    /**
-     * Get the exchange on which the stock is traded
-     * 
-     * @return the exchange or null if the data is not available
-     */
-    public String getStockExchange() {
-        return stockExchange;
-    }
-    
-    public void setStockExchange(String stockExchange) {
-        this.stockExchange = stockExchange;
-    }
-    
-    @Override
-    public String toString() {
-        return this.symbol + ": " + this.quote.getPrice();
-    }
-    
-    public void print() {
-        System.out.println(this.symbol);
-        System.out.println("--------------------------------");
-        for (Field f : this.getClass().getDeclaredFields()) {
-            try {
-                System.out.println(f.getName() + ": " + f.get(this));
-            } catch (IllegalArgumentException ex) {
-                log.error(null, ex);
-            } catch (IllegalAccessException ex) {
-                log.error(null, ex);
-            }
-        }
-        System.out.println("--------------------------------");
-    }
-    
+    return quotes;
+  }
+
+  private HistoricalQuote parseCSVLine(String line) {
+    String[] data = line.split(YahooFinance.QUOTES_CSV_DELIMITER);
+    return new HistoricalQuote(this.symbol,
+            Utils.parseHistDate(data[0]),
+            Utils.getBigDecimal(data[1]),
+            Utils.getBigDecimal(data[3]),
+            Utils.getBigDecimal(data[2]),
+            Utils.getBigDecimal(data[4]),
+            Utils.getBigDecimal(data[6]),
+            Utils.getLong(data[5])
+    );
+  }
+
+  private HistoricalQuote parseCSVLine2(String line) {
+    String[] data = line.split(YahooFinance.QUOTES_CSV_DELIMITER);
+    return new HistoricalQuote(this.symbol,
+          Utils.parseHistDate(data[0]),
+          Utils.getBigDecimal(data[1]),
+          Utils.getBigDecimal(data[3]),
+          Utils.getBigDecimal(data[2]),
+          Utils.getBigDecimal(data[4]),
+          Utils.getBigDecimal(data[5]),
+          Utils.getLong(data[6])
+    );
+  }
 }

--- a/src/main/java/yahoofinance/TablesawStock.java
+++ b/src/main/java/yahoofinance/TablesawStock.java
@@ -1,0 +1,27 @@
+package yahoofinance;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import tech.tablesaw.api.Table;
+
+/**
+ * @author Stijn Strickx
+ */
+public class TablesawStock extends AbstractStock<Table> {
+
+  public TablesawStock(String symbol) {
+    super(symbol);
+  }
+
+  @Override
+  protected Table transform(String csv) {
+    try {
+      return Table.read().csv(new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8)), symbol);
+    } catch (IOException e) {
+      throw new IllegalStateException("Could not transform CSV to Table", e);
+    }
+  }
+
+}

--- a/src/test/java/yahoofinance/HistoricalQuoteRequestTest.java
+++ b/src/test/java/yahoofinance/HistoricalQuoteRequestTest.java
@@ -9,7 +9,6 @@ import yahoofinance.mock.MockedServersTest;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Calendar;
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.*;
@@ -131,25 +130,14 @@ public class HistoricalQuoteRequestTest extends MockedServersTest {
         assertEquals(261, goog.getHistory().size());
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void impossibleRequestTest() throws IOException {
         Calendar from = Calendar.getInstance();
         Calendar to = Calendar.getInstance();
         from.add(Calendar.DATE, 2); // from > to
-        Exception reqEx = null;
 
         Stock goog = YahooFinance.get("GOOG");
-        List<HistoricalQuote> histQuotes = null;
-        int requestCount = MockedServersTest.histQuotesServer.getRequestCount();
-        try {
-            histQuotes = goog.getHistory(from, to);
-        } catch (IOException ex) {
-            reqEx = ex;
-        }
-        // Didn't send any requests since the problem was detected
-        assertEquals(requestCount, MockedServersTest.histQuotesServer.getRequestCount());
-        assertNull(reqEx);
-        assertEquals(0, histQuotes.size());
+        goog.getHistory(from, to);
     }
 
 }


### PR DESCRIPTION
Fix for https://github.com/sstrickx/yahoofinance-api/issues/88

No change for most users. You can now create a `CsvStock` or `TablesawStock` if you wish to get quotes in a different format.