### PR TITLE
Add historical dividends and splits - this closes #78 and closes #99

### DIFF
--- a/src/main/java/yahoofinance/Stock.java
+++ b/src/main/java/yahoofinance/Stock.java
@@ -11,7 +11,11 @@ import org.slf4j.LoggerFactory;
 import yahoofinance.histquotes.HistQuotesRequest;
 import yahoofinance.histquotes.HistoricalQuote;
 import yahoofinance.histquotes.Interval;
+import yahoofinance.histquotes2.HistDividendsRequest;
 import yahoofinance.histquotes2.HistQuotes2Request;
+import yahoofinance.histquotes2.HistSplitsRequest;
+import yahoofinance.histquotes2.HistoricalDividend;
+import yahoofinance.histquotes2.HistoricalSplit;
 import yahoofinance.quotes.stock.StockDividend;
 import yahoofinance.quotes.stock.StockQuote;
 import yahoofinance.quotes.stock.StockQuotesData;
@@ -36,6 +40,8 @@ public class Stock {
     private StockDividend dividend;
     
     private List<HistoricalQuote> history;
+    private List<HistoricalDividend> dividendHistory;
+    private List<HistoricalSplit> splitHistory;
     
     public Stock(String symbol) {
         this.symbol = symbol;
@@ -311,6 +317,152 @@ public class Stock {
     
     public void setHistory(List<HistoricalQuote> history) {
         this.history = history;
+    }
+    
+    /**
+     * This method will return historical dividends from this stock.
+     * If the historical dividends are not available yet, they will 
+     * be requested first from Yahoo Finance.
+     * <p>
+     * If the historical dividends are not available yet, the
+     * following characteristics will be used for the request:
+     * <ul>
+     * <li> from: 1 year ago (default)
+     * <li> to: today (default)
+     * </ul>
+     * <p>
+     * There are several more methods available that allow you
+     * to define some characteristics of the historical data.
+     * Calling one of those methods will result in a new request
+     * being sent to Yahoo Finance.
+     * 
+     * @return      a list of historical dividends from this stock
+     * @throws java.io.IOException when there's a connection problem
+     * @see         #getDividendHistory(java.util.Calendar) 
+     * @see         #getDividendHistory(java.util.Calendar, java.util.Calendar) 
+     */
+    public List<HistoricalDividend> getDividendHistory() throws IOException {
+        if(this.dividendHistory != null) {
+            return this.dividendHistory;
+        }
+        return this.getDividendHistory(HistDividendsRequest.DEFAULT_FROM);
+    }
+    
+    /**
+     * Requests the historical dividends for this stock with the following characteristics.
+     * <ul>
+     * <li> from: specified value
+     * <li> to: today (default)
+     * </ul>
+     * 
+     * @param from          start date of the historical data
+     * @return              a list of historical dividends from this stock
+     * @throws java.io.IOException when there's a connection problem
+     * @see                 #getDividendHistory() 
+     */
+    public List<HistoricalDividend> getDividendHistory(Calendar from) throws IOException {
+        return this.getDividendHistory(from, HistDividendsRequest.DEFAULT_TO);
+    }
+    
+    /**
+     * Requests the historical dividends for this stock with the following characteristics.
+     * <ul>
+     * <li> from: specified value
+     * <li> to: specified value
+     * </ul>
+     * 
+     * @param from          start date of the historical data
+     * @param to            end date of the historical data
+     * @return              a list of historical dividends from this stock
+     * @throws java.io.IOException when there's a connection problem
+     * @see                 #getDividendHistory() 
+     */
+    public List<HistoricalDividend> getDividendHistory(Calendar from, Calendar to) throws IOException {
+        if(YahooFinance.HISTQUOTES2_ENABLED.equalsIgnoreCase("true")) {
+            HistDividendsRequest histDiv = new HistDividendsRequest(this.symbol, from, to);
+            this.setDividendHistory(histDiv.getResult());
+        } else {
+        	// Historical dividends cannot be retrieved without CRUMB
+        	this.setDividendHistory(null);
+        }
+        return this.dividendHistory;
+    }
+    
+    public void setDividendHistory(List<HistoricalDividend> dividendHistory) {
+        this.dividendHistory = dividendHistory;
+    }
+    
+    /**
+     * This method will return historical splits from this stock.
+     * If the historical splits are not available yet, they will 
+     * be requested first from Yahoo Finance.
+     * <p>
+     * If the historical splits are not available yet, the
+     * following characteristics will be used for the request:
+     * <ul>
+     * <li> from: 1 year ago (default)
+     * <li> to: today (default)
+     * </ul>
+     * <p>
+     * There are several more methods available that allow you
+     * to define some characteristics of the historical data.
+     * Calling one of those methods will result in a new request
+     * being sent to Yahoo Finance.
+     * 
+     * @return      a list of historical splits from this stock
+     * @throws java.io.IOException when there's a connection problem
+     * @see         #getSplitHistory(java.util.Calendar) 
+     * @see         #getSplitHistory(java.util.Calendar, java.util.Calendar) 
+     */
+    public List<HistoricalSplit> getSplitHistory() throws IOException {
+        if(this.splitHistory != null) {
+            return this.splitHistory;
+        }
+        return this.getSplitHistory(HistSplitsRequest.DEFAULT_FROM);
+    }
+    
+    /**
+     * Requests the historical splits for this stock with the following characteristics.
+     * <ul>
+     * <li> from: specified value
+     * <li> to: today (default)
+     * </ul>
+     * 
+     * @param from          start date of the historical data
+     * @return              a list of historical splits from this stock
+     * @throws java.io.IOException when there's a connection problem
+     * @see                 #getSplitHistory() 
+     */
+    public List<HistoricalSplit> getSplitHistory(Calendar from) throws IOException {
+        return this.getSplitHistory(from, HistSplitsRequest.DEFAULT_TO);
+    }
+    
+    /**
+     * Requests the historical splits for this stock with the following characteristics.
+     * <ul>
+     * <li> from: specified value
+     * <li> to: specified value
+     * </ul>
+     * 
+     * @param from          start date of the historical data
+     * @param to            end date of the historical data
+     * @return              a list of historical splits from this stock
+     * @throws java.io.IOException when there's a connection problem
+     * @see                 #getSplitHistory() 
+     */
+    public List<HistoricalSplit> getSplitHistory(Calendar from, Calendar to) throws IOException {
+        if(YahooFinance.HISTQUOTES2_ENABLED.equalsIgnoreCase("true")) {
+            HistSplitsRequest histSplit = new HistSplitsRequest(this.symbol, from, to);
+            this.setSplitHistory(histSplit.getResult());
+        } else {
+        	// Historical splits cannot be retrieved without CRUMB
+        	this.setSplitHistory(null);
+        }
+        return this.splitHistory;
+    }
+    
+    public void setSplitHistory(List<HistoricalSplit> splitHistory) {
+        this.splitHistory = splitHistory;
     }
     
     public String getSymbol() {

--- a/src/main/java/yahoofinance/histquotes2/HistDividendsRequest.java
+++ b/src/main/java/yahoofinance/histquotes2/HistDividendsRequest.java
@@ -1,0 +1,130 @@
+package yahoofinance.histquotes2;
+
+import yahoofinance.Utils;
+import yahoofinance.YahooFinance;
+import yahoofinance.util.RedirectableRequest;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLEncoder;
+import java.util.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author Stijn Strickx (modified by Randle McMurphy)
+ */
+public class HistDividendsRequest {
+
+
+    private static final Logger log = LoggerFactory.getLogger(HistDividendsRequest.class);
+    private final String symbol;
+
+    private final Calendar from;
+    private final Calendar to;
+
+    public static final Calendar DEFAULT_FROM = Calendar.getInstance();
+
+    static {
+        DEFAULT_FROM.add(Calendar.YEAR, -1);
+    }
+    public static final Calendar DEFAULT_TO = Calendar.getInstance();
+
+    // Interval has no meaning here and is not used here
+    // But it's better to leave it because Yahoo's standard query URL still contains it
+    public static final QueryInterval DEFAULT_INTERVAL = QueryInterval.DAILY;
+
+    public HistDividendsRequest(String symbol) {
+        this(symbol, DEFAULT_FROM, DEFAULT_TO);
+    }
+
+    public HistDividendsRequest(String symbol, Calendar from, Calendar to) {
+        this.symbol = symbol;
+        this.from = this.cleanHistCalendar(from);
+        this.to = this.cleanHistCalendar(to);
+    }
+
+    public HistDividendsRequest(String symbol, Date from, Date to) {
+        this(symbol);
+        this.from.setTime(from);
+        this.to.setTime(to);
+        this.cleanHistCalendar(this.from);
+        this.cleanHistCalendar(this.to);
+    }
+
+    /**
+     * Put everything smaller than days at 0
+     * @param cal calendar to be cleaned
+     */
+    private Calendar cleanHistCalendar(Calendar cal) {
+        cal.set(Calendar.MILLISECOND, 0);
+        cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.MINUTE, 0);
+        cal.set(Calendar.HOUR, 0);
+        return cal;
+    }
+
+    public List<HistoricalDividend> getResult() throws IOException {
+
+        List<HistoricalDividend> result = new ArrayList<HistoricalDividend>();
+        
+        if(this.from.after(this.to)) {
+            log.warn("Unable to retrieve historical dividends. "
+                    + "From-date should not be after to-date. From: "
+                    + this.from.getTime() + ", to: " + this.to.getTime());
+            return result;
+        }
+
+        Map<String, String> params = new LinkedHashMap<String, String>();
+        params.put("period1", String.valueOf(this.from.getTimeInMillis() / 1000));
+        params.put("period2", String.valueOf(this.to.getTimeInMillis() / 1000));
+
+        // Interval has no meaning here and is not used here
+        // But it's better to leave it because Yahoo's standard query URL still contains it
+        params.put("interval", DEFAULT_INTERVAL.getTag());
+        
+        // This will instruct Yahoo to return dividends
+        params.put("events", "div");
+
+        params.put("crumb", CrumbManager.getCrumb());
+
+        String url = YahooFinance.HISTQUOTES2_BASE_URL + URLEncoder.encode(this.symbol , "UTF-8") + "?" + Utils.getURLParameters(params);
+
+        // Get CSV from Yahoo
+        log.info("Sending request: " + url);
+
+        URL request = new URL(url);
+        RedirectableRequest redirectableRequest = new RedirectableRequest(request, 5);
+        redirectableRequest.setConnectTimeout(YahooFinance.CONNECTION_TIMEOUT);
+        redirectableRequest.setReadTimeout(YahooFinance.CONNECTION_TIMEOUT);
+        Map<String, String> requestProperties = new HashMap<String, String>();
+        requestProperties.put("Cookie", CrumbManager.getCookie());
+        URLConnection connection = redirectableRequest.openConnection(requestProperties);
+
+        InputStreamReader is = new InputStreamReader(connection.getInputStream());
+        BufferedReader br = new BufferedReader(is);
+        br.readLine(); // skip the first line
+        // Parse CSV
+        for (String line = br.readLine(); line != null; line = br.readLine()) {
+
+            log.info("Parsing CSV line: " + Utils.unescape(line));
+            HistoricalDividend dividend = this.parseCSVLine(line);
+            result.add(dividend);
+        }
+        return result;
+    }
+
+    private HistoricalDividend parseCSVLine(String line) {
+        String[] data = line.split(YahooFinance.QUOTES_CSV_DELIMITER);
+        return new HistoricalDividend(this.symbol,
+                Utils.parseHistDate(data[0]),
+                Utils.getBigDecimal(data[1])
+        );
+    }
+
+}

--- a/src/main/java/yahoofinance/histquotes2/HistSplitsRequest.java
+++ b/src/main/java/yahoofinance/histquotes2/HistSplitsRequest.java
@@ -1,0 +1,132 @@
+package yahoofinance.histquotes2;
+
+import yahoofinance.Utils;
+import yahoofinance.YahooFinance;
+import yahoofinance.util.RedirectableRequest;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLEncoder;
+import java.util.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author Stijn Strickx (modified by Randle McMurphy)
+ */
+public class HistSplitsRequest {
+
+
+    private static final Logger log = LoggerFactory.getLogger(HistSplitsRequest.class);
+    private final String symbol;
+
+    private final Calendar from;
+    private final Calendar to;
+
+    public static final Calendar DEFAULT_FROM = Calendar.getInstance();
+
+    static {
+        DEFAULT_FROM.add(Calendar.YEAR, -1);
+    }
+    public static final Calendar DEFAULT_TO = Calendar.getInstance();
+
+    // Interval has no meaning here and is not used here
+    // But it's better to leave it because Yahoo's standard query URL still contains it
+    public static final QueryInterval DEFAULT_INTERVAL = QueryInterval.DAILY;
+
+    public HistSplitsRequest(String symbol) {
+        this(symbol, DEFAULT_FROM, DEFAULT_TO);
+    }
+
+    public HistSplitsRequest(String symbol, Calendar from, Calendar to) {
+        this.symbol = symbol;
+        this.from = this.cleanHistCalendar(from);
+        this.to = this.cleanHistCalendar(to);
+    }
+
+    public HistSplitsRequest(String symbol, Date from, Date to) {
+        this(symbol);
+        this.from.setTime(from);
+        this.to.setTime(to);
+        this.cleanHistCalendar(this.from);
+        this.cleanHistCalendar(this.to);
+    }
+
+    /**
+     * Put everything smaller than days at 0
+     * @param cal calendar to be cleaned
+     */
+    private Calendar cleanHistCalendar(Calendar cal) {
+        cal.set(Calendar.MILLISECOND, 0);
+        cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.MINUTE, 0);
+        cal.set(Calendar.HOUR, 0);
+        return cal;
+    }
+
+    public List<HistoricalSplit> getResult() throws IOException {
+
+        List<HistoricalSplit> result = new ArrayList<HistoricalSplit>();
+        
+        if(this.from.after(this.to)) {
+            log.warn("Unable to retrieve historical splits. "
+                    + "From-date should not be after to-date. From: "
+                    + this.from.getTime() + ", to: " + this.to.getTime());
+            return result;
+        }
+
+        Map<String, String> params = new LinkedHashMap<String, String>();
+        params.put("period1", String.valueOf(this.from.getTimeInMillis() / 1000));
+        params.put("period2", String.valueOf(this.to.getTimeInMillis() / 1000));
+
+        // Interval has no meaning here and is not used here
+        // But it's better to leave it because Yahoo's standard query URL still contains it
+        params.put("interval", DEFAULT_INTERVAL.getTag());
+        
+        // This will instruct Yahoo to return splits
+        params.put("events", "split");
+
+        params.put("crumb", CrumbManager.getCrumb());
+
+        String url = YahooFinance.HISTQUOTES2_BASE_URL + URLEncoder.encode(this.symbol , "UTF-8") + "?" + Utils.getURLParameters(params);
+
+        // Get CSV from Yahoo
+        log.info("Sending request: " + url);
+
+        URL request = new URL(url);
+        RedirectableRequest redirectableRequest = new RedirectableRequest(request, 5);
+        redirectableRequest.setConnectTimeout(YahooFinance.CONNECTION_TIMEOUT);
+        redirectableRequest.setReadTimeout(YahooFinance.CONNECTION_TIMEOUT);
+        Map<String, String> requestProperties = new HashMap<String, String>();
+        requestProperties.put("Cookie", CrumbManager.getCookie());
+        URLConnection connection = redirectableRequest.openConnection(requestProperties);
+
+        InputStreamReader is = new InputStreamReader(connection.getInputStream());
+        BufferedReader br = new BufferedReader(is);
+        br.readLine(); // skip the first line
+        // Parse CSV
+        for (String line = br.readLine(); line != null; line = br.readLine()) {
+
+            log.info("Parsing CSV line: " + Utils.unescape(line));
+            HistoricalSplit split = this.parseCSVLine(line);
+            result.add(split);
+        }
+        return result;
+    }
+
+    private HistoricalSplit parseCSVLine(String line) {
+        String[] data = line.split(YahooFinance.QUOTES_CSV_DELIMITER);
+    	String[] parts = data[1].split("/");
+        return new HistoricalSplit(this.symbol,
+                Utils.parseHistDate(data[0]),
+                Utils.getBigDecimal(parts[0]),
+                Utils.getBigDecimal(parts[1])
+        );
+    }
+
+}

--- a/src/main/java/yahoofinance/histquotes2/HistoricalDividend.java
+++ b/src/main/java/yahoofinance/histquotes2/HistoricalDividend.java
@@ -1,0 +1,66 @@
+package yahoofinance.histquotes2;
+
+import java.math.BigDecimal;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+
+/**
+ * At the time of this writing Yahoo returns ADJUSTED dividends. Which means that as soon as
+ * split occurs, all past dividends are divided by split factor.
+ * All getters can return null in case the data is not available from Yahoo Finance.
+ * 
+ * @author Randle McMurphy
+ */
+public class HistoricalDividend {
+	
+    private String symbol;
+    
+    private Calendar date;
+    
+    private BigDecimal adjDividend;
+    
+    public HistoricalDividend() {}
+
+    public HistoricalDividend(String symbol, Calendar date, BigDecimal adjDividend) {
+        this.symbol = symbol;
+        this.date = date;
+        this.adjDividend = adjDividend;
+    }
+
+    public String getSymbol() {
+        return symbol;
+    }
+
+    public void setSymbol(String symbol) {
+        this.symbol = symbol;
+    }
+    
+    public Calendar getDate() {
+        return date;
+    }
+
+    public void setDate(Calendar date) {
+        this.date = date;
+    }
+
+    /**
+     * At the time of this writing Yahoo returns ADJUSTED dividends. Which means that as soon as
+     * split occurs, all past dividends are divided by split factor.
+     * 
+     * @return      an adjusted dividend cash
+     */
+    public BigDecimal getAdjDividend() {
+        return adjDividend;
+    }
+
+    public void setAdjDividend(BigDecimal adjDividend) {
+        this.adjDividend = adjDividend;
+    }
+
+    @Override
+    public String toString() {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        String dateStr = dateFormat.format(this.date.getTime());
+        return "DIVIDEND: " + this.symbol + "@" + dateStr + ": " + this.adjDividend;
+    }
+}

--- a/src/main/java/yahoofinance/histquotes2/HistoricalSplit.java
+++ b/src/main/java/yahoofinance/histquotes2/HistoricalSplit.java
@@ -1,0 +1,77 @@
+package yahoofinance.histquotes2;
+
+import java.math.BigDecimal;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+
+/**
+ * All getters can return null in case the data is not available from Yahoo Finance.
+ * 
+ * @author Randle McMurphy
+ */
+public class HistoricalSplit {
+	
+    private String symbol;
+    
+    private Calendar date;
+    
+    private BigDecimal numerator;
+    private BigDecimal denumerator;
+    
+    public HistoricalSplit() {}
+
+    public HistoricalSplit(String symbol, Calendar date, BigDecimal numerator, BigDecimal denumerator) {
+        this.symbol = symbol;
+        this.date = date;
+        this.numerator = numerator;
+        this.denumerator = denumerator;
+    }
+
+    public String getSymbol() {
+        return symbol;
+    }
+
+    public void setSymbol(String symbol) {
+        this.symbol = symbol;
+    }
+    
+    public Calendar getDate() {
+        return date;
+    }
+
+    public void setDate(Calendar date) {
+        this.date = date;
+    }
+
+    public BigDecimal getNumerator() {
+        return numerator;
+    }
+
+    public void setNumerator(BigDecimal numerator) {
+        this.numerator = numerator;
+    }
+
+    public BigDecimal getDenumerator() {
+        return denumerator;
+    }
+
+    public void setDenumerator(BigDecimal denumerator) {
+        this.denumerator = denumerator;
+    }
+
+    /**
+     * 
+     * @return      a calculated split factor value which is equal to numerator divided by denumerator
+     */
+    public BigDecimal getSplitFactor() {
+        return numerator.divide(denumerator);
+    }
+
+    @Override
+    public String toString() {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        String dateStr = dateFormat.format(this.date.getTime());
+        return "SPLIT: " + this.symbol + "@" + dateStr + ": " + this.numerator + " / " + this.denumerator;
+    }
+
+}


### PR DESCRIPTION
A few methods are added to `Stock` class:
```
List<HistoricalDividend> getDividendHistory()
List<HistoricalDividend> getDividendHistory(Calendar from)
List<HistoricalDividend> getDividendHistory(Calendar from, Calendar to)

List<HistoricalSplit> getSplitHistory()
List<HistoricalSplit> getSplitHistory(Calendar from)
List<HistoricalSplit> getSplitHistory(Calendar from, Calendar to)
```

Two request classes are added. Both are very similar to `HistQuotes2Request` but they don't use `QueryInterval`:
```
HistDividendsRequest
HistSplitsRequest
```
Two domain classes are added:
```
HistoricalDividend
HistoricalSplit
```