### PR TITLE
Fixes NPE when symbol is not upper case

### DIFF
--- a/src/main/java/yahoofinance/YahooFinance.java
+++ b/src/main/java/yahoofinance/YahooFinance.java
@@ -90,7 +90,7 @@ public class YahooFinance {
      */
     public static Stock get(String symbol, boolean includeHistorical) throws IOException {
         Map<String, Stock> result = YahooFinance.getQuotes(symbol, includeHistorical);
-        return result.get(symbol);
+        return result.get(symbol.toUpperCase());
     }
     
     /**


### PR DESCRIPTION
In YahooFinanceAPI on line 89 result is returned from a map by using a passed symbol. When that map is populated the symbol is used from returned data. So if I pass "googl", the map key will be "GOOGL". This means the `map.get(symbol)` returns a null if case is not correct. This behavior did not exist in older version (when passing "googl" it worked fine).