### PR TITLE
Proposed changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.0</version>
+            <version>2.9.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/yahoofinance/Stock.java
+++ b/src/main/java/yahoofinance/Stock.java
@@ -1,6 +1,7 @@
 package yahoofinance;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.util.Calendar;
 import java.util.List;
@@ -27,7 +28,7 @@ import yahoofinance.quotes.stock.StockStats;
  *
  * @author Stijn Strickx
  */
-public class Stock {
+public class Stock implements Serializable{
 
     private static final Logger log = LoggerFactory.getLogger(Stock.class);
   

--- a/src/main/java/yahoofinance/histquotes/HistoricalQuote.java
+++ b/src/main/java/yahoofinance/histquotes/HistoricalQuote.java
@@ -1,6 +1,7 @@
 
 package yahoofinance.histquotes;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -10,7 +11,7 @@ import java.util.Calendar;
  * 
  * @author Stijn Strickx
  */
-public class HistoricalQuote {
+public class HistoricalQuote implements Serializable {
     
     private String symbol;
     

--- a/src/main/java/yahoofinance/quotes/stock/StockDividend.java
+++ b/src/main/java/yahoofinance/quotes/stock/StockDividend.java
@@ -1,6 +1,7 @@
 
 package yahoofinance.quotes.stock;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Calendar;
 
@@ -9,7 +10,7 @@ import java.util.Calendar;
  * 
  * @author Stijn Strickx
  */
-public class StockDividend {
+public class StockDividend implements Serializable {
     
     private final String symbol;
     

--- a/src/main/java/yahoofinance/quotes/stock/StockQuote.java
+++ b/src/main/java/yahoofinance/quotes/stock/StockQuote.java
@@ -1,6 +1,7 @@
 
 package yahoofinance.quotes.stock;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Calendar;
 import java.util.TimeZone;
@@ -11,7 +12,7 @@ import yahoofinance.Utils;
  * 
  * @author Stijn Strickx
  */
-public class StockQuote {
+public class StockQuote implements Serializable {
     
     private final String symbol;
     

--- a/src/main/java/yahoofinance/quotes/stock/StockStats.java
+++ b/src/main/java/yahoofinance/quotes/stock/StockStats.java
@@ -1,6 +1,7 @@
 
 package yahoofinance.quotes.stock;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Calendar;
 
@@ -11,7 +12,7 @@ import yahoofinance.Utils;
  * 
  * @author Stijn Strickx
  */
-public class StockStats {
+public class StockStats implements Serializable {
     
     private final String symbol;
     

--- a/src/main/java/yahoofinance/stockfilters/MovingAverage.java
+++ b/src/main/java/yahoofinance/stockfilters/MovingAverage.java
@@ -1,0 +1,47 @@
+package yahoofinance.stockfilters;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import yahoofinance.histquotes.HistoricalQuote;
+
+/***
+ * 
+ * @author Austin McElroy
+ *
+ */
+
+public class MovingAverage implements StockFilter{
+
+	int length = 200;
+	
+	public MovingAverage(int length){
+		this.length = length;
+	}
+	
+	@Override
+	public List<StockFilterQuote> filter(List<HistoricalQuote> input) {
+		if(input.size() < length) {
+			return null;
+		}
+		
+		ArrayList<StockFilterQuote> results = new ArrayList<StockFilterQuote>();
+		
+		for(int i = length; i < input.size(); i++) {
+			float mvg_avg = 0;
+			for(int j = 0; j < length; j++) {
+				mvg_avg += input.get(i - j).getClose().floatValue();
+			}
+			mvg_avg /= length;
+			
+			StockFilterQuote sfq = new StockFilterQuote(input.get(i));
+			sfq.setResult(mvg_avg);	
+			
+			results.add(sfq);
+		}
+		
+		
+		return results;
+	}
+
+}

--- a/src/main/java/yahoofinance/stockfilters/StockFilter.java
+++ b/src/main/java/yahoofinance/stockfilters/StockFilter.java
@@ -1,0 +1,16 @@
+package yahoofinance.stockfilters;
+
+import java.util.List;
+
+import yahoofinance.histquotes.HistoricalQuote;
+
+/***
+ * 
+ * @author Austin McElroy
+ *
+ */
+
+public interface StockFilter {
+
+	List<StockFilterQuote> filter(List<HistoricalQuote> input);
+}

--- a/src/main/java/yahoofinance/stockfilters/StockFilterQuote.java
+++ b/src/main/java/yahoofinance/stockfilters/StockFilterQuote.java
@@ -1,0 +1,29 @@
+package yahoofinance.stockfilters;
+
+import java.util.Calendar;
+
+import yahoofinance.histquotes.HistoricalQuote;
+
+/***
+ * 
+ * @author Austin McElroy
+ *
+ */
+
+public class StockFilterQuote {
+	Calendar _date;
+	
+	float _filteredResult;
+	
+	public StockFilterQuote(HistoricalQuote hq) {
+		_date = hq.getDate();
+	}
+	
+	public void setResult(float result) {
+		_filteredResult = result;
+	}
+	
+	public float getResult() {
+		return _filteredResult;
+	}
+}


### PR DESCRIPTION
Changed pom.xml: updated com.fastercml.jackson.core->jackson-databind to 2.9.6 from 2.9.0
Added the Serializable interface to Stock, HistoricalQuote, StockDividend, StockQuote, StockStats

The update to serializable is useful to save the data using ObjectInputStream and ObjectOutputStream to develop algorithms within the framework of the yahoofinance-api without having to re-query the Yahoo server each time. 

Example to use:
```
Stock intel = YahooFinance.get("INTC", from, to, Interval.MONTHLY);
String fileName= System.getProperty("user.dir") + "\\Intel.java_object";
FileOutputStream fos = new FileOutputStream(fileName);
ObjectOutputStream oos = new ObjectOutputStream(fos);
oos.writeObject(intel);
oos.close();
	        
FileInputStream fis = new FileInputStream(fileName);
ObjectInputStream ois = new ObjectInputStream(fis);
Stock savedStock = (Stock)ois.readObject();
ois.close();
```

 