### PR TITLE
Fix pattern to identify start of consent form

### DIFF
--- a/src/main/java/yahoofinance/histquotes2/CrumbManager.java
+++ b/src/main/java/yahoofinance/histquotes2/CrumbManager.java
@@ -67,7 +67,7 @@ public class CrumbManager {
         InputStreamReader is = new InputStreamReader(connection.getInputStream());
         BufferedReader br = new BufferedReader(is);
         String line;
-        Pattern patternPostForm = Pattern.compile("(.*)(method=\"post\" action=\"/consent\")(.*)");
+        Pattern patternPostForm = Pattern.compile("(.*)(action=\"/consent\")(.*)");
         Pattern patternInput = Pattern.compile("(.*)(<input type=\"hidden\" name=\")(.*?)(\" value=\")(.*?)(\">)");
         Matcher matcher;
         Map<String,String> datas = new HashMap<String,String>();


### PR DESCRIPTION
The html changed so the existing pattern stopped working.

None of the existing tests caught this problem because they mock everything. Perhaps there should be some additional tests that actually send requests to Yahoo.