### PR TITLE
Fix parsing of split history server response.

### DIFF
--- a/src/main/java/yahoofinance/histquotes2/HistSplitsRequest.java
+++ b/src/main/java/yahoofinance/histquotes2/HistSplitsRequest.java
@@ -119,9 +119,9 @@ public class HistSplitsRequest {
         return result;
     }
 
-    private HistoricalSplit parseCSVLine(String line) {
+    HistoricalSplit parseCSVLine(String line) {
         String[] data = line.split(YahooFinance.QUOTES_CSV_DELIMITER);
-    	String[] parts = data[1].split("/");
+    	String[] parts = data[1].split(":");
         return new HistoricalSplit(this.symbol,
                 Utils.parseHistDate(data[0]),
                 Utils.getBigDecimal(parts[0]),

--- a/src/main/java/yahoofinance/histquotes2/HistoricalSplit.java
+++ b/src/main/java/yahoofinance/histquotes2/HistoricalSplit.java
@@ -75,4 +75,25 @@ public class HistoricalSplit {
         return "SPLIT: " + this.symbol + "@" + dateStr + ": " + this.numerator + " / " + this.denominator;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        HistoricalSplit that = (HistoricalSplit) o;
+
+        if (symbol != null ? !symbol.equals(that.symbol) : that.symbol != null) return false;
+        if (date != null ? !date.equals(that.date) : that.date != null) return false;
+        if (numerator != null ? !numerator.equals(that.numerator) : that.numerator != null) return false;
+        return denominator != null ? denominator.equals(that.denominator) : that.denominator == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = symbol != null ? symbol.hashCode() : 0;
+        result = 31 * result + (date != null ? date.hashCode() : 0);
+        result = 31 * result + (numerator != null ? numerator.hashCode() : 0);
+        result = 31 * result + (denominator != null ? denominator.hashCode() : 0);
+        return result;
+    }
 }

--- a/src/test/java/yahoofinance/histquotes2/HistSplitsRequestTest.java
+++ b/src/test/java/yahoofinance/histquotes2/HistSplitsRequestTest.java
@@ -1,0 +1,21 @@
+package yahoofinance.histquotes2;
+
+import junit.framework.TestCase;
+
+import java.math.BigDecimal;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+public class HistSplitsRequestTest extends TestCase {
+
+    public void testParseCSVLine() {
+        String input = "2020-08-31,4:1";
+        HistoricalSplit actual = new HistSplitsRequest("AAPL").parseCSVLine(input);
+        HistoricalSplit expected = new HistoricalSplit("AAPL",
+                new GregorianCalendar(2020, Calendar.AUGUST, 31),
+                BigDecimal.valueOf(4),
+                BigDecimal.valueOf(1));
+        assertEquals(expected, actual);
+    }
+
+}


### PR DESCRIPTION
# Purpose 
Fix issue #163 

# Implementation
The main change here is in the `HistSplitsRequest` class on the line 124. Probably server has changed the output format for numerator and denominator. Now the delimiter between these values is `:`.

Added test for this case.