### PR TITLE
Fix Split History : ArrayIndexOutOfBoundsException issue #183

### DIFF
--- a/src/main/java/yahoofinance/histquotes2/HistSplitsRequest.java
+++ b/src/main/java/yahoofinance/histquotes2/HistSplitsRequest.java
@@ -121,7 +121,7 @@ public class HistSplitsRequest {
 
     private HistoricalSplit parseCSVLine(String line) {
         String[] data = line.split(YahooFinance.QUOTES_CSV_DELIMITER);
-    	String[] parts = data[1].split("/");
+    	String[] parts = data[1].split(":");
         return new HistoricalSplit(this.symbol,
                 Utils.parseHistDate(data[0]),
                 Utils.getBigDecimal(parts[0]),


### PR DESCRIPTION
Change the Split History delimiter from "/" to ":"