### PR TITLE
add crumb param to QUOTES_QUERY1V7_BASE_URL

### DIFF
--- a/src/main/java/yahoofinance/quotes/query1v7/QuotesRequest.java
+++ b/src/main/java/yahoofinance/quotes/query1v7/QuotesRequest.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import yahoofinance.Utils;
 import yahoofinance.YahooFinance;
+import yahoofinance.histquotes2.CrumbManager;
 import yahoofinance.util.RedirectableRequest;
 
 import java.io.IOException;
@@ -60,7 +61,7 @@ public abstract class QuotesRequest<T> {
         Map<String, String> params = new LinkedHashMap<String, String>();
         params.put("symbols", this.symbols);
 
-        String url = YahooFinance.QUOTES_QUERY1V7_BASE_URL + "?" + Utils.getURLParameters(params);
+        String url = YahooFinance.QUOTES_QUERY1V7_BASE_URL + "?" + Utils.getURLParameters(params) + "&crumb=" + CrumbManager.getCrumb();
 
         // Get JSON from Yahoo
         log.info("Sending request: " + url);


### PR DESCRIPTION
I add the 'crumb' parameter in the requests.
The request used to look like this: https://query1.finance.yahoo.com/v7/finance/quote?symbols=BTC-USD and returned the following data: {"finance":{"result":null,"error":{"code":"Unauthorized","description":"Invalid Crumb. For Developers - https://bit.ly/yahoo-finance-api-feedback"}}}. 
Now the request looks like this: https://query1.finance.yahoo.com/v7/finance/quote?symbols=BTC-USD&crumb=nd4hh33CCOP and and returns data about the stock. 